### PR TITLE
VOSA-228: publication webapps now get access logs again

### DIFF
--- a/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
@@ -378,7 +378,7 @@ EOF
                />
     <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
       <Valve className="org.apache.catalina.valves.AccessLogValve"
-             prefix="access."
+             prefix="access-publications."
              suffix=".log"
              pattern="common"
              />


### PR DESCRIPTION
This is a regression of 702368fc8b8ed80e368fe172c44cdb68e24d28bc when
a separate HTTP connector for the publication webapps was set
up. Since the access log valve has the same prefix as the one defined
for the defualt HTTP connector, the second valve wasn't working. As a
result, access log entries for the publication webapps were no longer
available on the system.