### PR TITLE
VF-6357 Must remove solr & lucene JARs after deploy on search intances

### DIFF
--- a/usr/share/escenic/ece-scripts/ece.d/deploy.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/deploy.sh
@@ -257,10 +257,12 @@ function remove_unwanted_libraries() {
     return
   elif [ ! -d $1 ]; then
     return
-  elif [ $type != "search" ]; then
-    return
+  elif [[ $type == "search" ]]; then
+    log "Removing $1/engine-config-*.jar since this is a search instance"
+    run rm $1/engine-config-*.jar
+    log "Removing global lucene JARs  (/solr has them)"
+    run rm $1/lucene-*.jar
+    log "Removing global solr JARs (/solr has them)"
+    run rm $1/solr-*.jar
   fi
-
-  log "Removing $1/engine-config-*.jar since this is a search instance"
-  run rm $1/engine-config-*.jar
 }


### PR DESCRIPTION
- since we ship with a different version of Solr in the WAR than we have
in the libraries directories.

- if not doing this, the solr webapp gets confused about the versions
(amazingly enough since the webapp should have its own sandbox)