### PR TITLE
Feature/vosa 229 standalone solr

### DIFF
--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -277,10 +277,10 @@ function install_common_os_packages()
         apt-key add - 1>> $log 2>> $log
       local package_pool=${fai_apt_vizrt_pool-unstable}
       add_apt_source "deb http://apt.vizrt.com ${package_pool} main"
+      run apt-get update
     fi
     install_packages_if_missing escenic-common-scripts
   fi
-
 }
 
 # don't quote values when setting conf file values with

--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -58,7 +58,7 @@ db_vendor=percona
 download_dir=${escenic_cache_dir}/$(basename $0)
 log=${escenic_log_dir}/$(basename $0).log
 conf_file=$HOME/ece-install.conf
-ece_scripts_git_source=https://github.com/vizrt/ece-scripts.git
+ece_scripts_git_source=https://github.com/escenic/ece-scripts.git
 maven_opts="--batch-mode"
 wget_opts="--continue --inet4-only --quiet"
 apt_opts="--no-install-recommends"
@@ -407,8 +407,8 @@ function print_status_and_next_steps()
     if [ $install_profile_number -ne $PROFILE_RESTORE_FROM_BACKUP -a \
         $install_profile_number -ne $PROFILE_CACHE_SERVER -a \
         $install_profile_number -ne $PROFILE_WIDGET_FRAMEWORK ]; then
-        add_next_step "Install info: "\ "/usr/share/doc/escenic/ece-install-guide.txt"
-        add_next_step "Guide books: http://documentation.vizrt.com/ece-5.5.html"
+        add_next_step "UNIX man pages: $(man -k escenic | awk '{print $1;}')"
+        add_next_step "Guide books: http://docs.escenic.com/ece-5.7.html"
     fi
 
     print_next_step_list

--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -83,25 +83,15 @@ force_packages=0
 ece_software_setup_completed=0
 
 ############################################################################
-# For ECE 5.5
+# For ECE 5.7
 ############################################################################
 technet_download_list="
-  http://technet.escenic.com/downloads/release/55/analysis-engine-2.5.0.131590.zip
-  http://technet.escenic.com/downloads/release/55/assemblytool-2.0.4.jar
-  http://technet.escenic.com/downloads/release/55/community-engine-3.8.1.132399.zip
-  http://technet.escenic.com/downloads/release/55/engine-5.5.0.131978.zip
-  http://technet.escenic.com/downloads/release/55/forum-3.2.1.132293.zip
-  http://technet.escenic.com/downloads/release/55/geocode-2.4.1.130693.zip
-  http://technet.escenic.com/downloads/release/55/lucy-4.2.1.129603.zip
-  http://technet.escenic.com/downloads/release/55/menu-editor-2.1.1.128528.zip
-  http://technet.escenic.com/downloads/release/55/online-graphics-1.0.1.133123.zip
-  http://technet.escenic.com/downloads/release/55/poll-2.3.0.128547.zip
-  http://technet.escenic.com/downloads/release/55/vcpeditor-1.0.0.132434.zip
-  http://technet.escenic.com/downloads/release/55/video-1.2.1.132710.zip
+http://maven.escenic.com/com/escenic/engine-dist/5.7.71.178665/engine-dist-5.7.71.178665-bin.zip
+https://maven.escenic.com/com/escenic/tools/assemblytool/2.0.7/assemblytool-2.0.7.zip
 "
+
 wf_download_list="
-  http://technet.escenic.com/downloads/release/55/framework-dist-2.0.2.131581.zip
-  http://technet.escenic.com/downloads/release/55/framework-community-dist-2.0.2.131581.zip
+https://maven.escenic.com/com/escenic/widget-framework/framework-dist/3.5.1.174428/framework-dist-3.5.1.174428.zip
 "
 ############################################################################
 
@@ -564,7 +554,7 @@ function check_software_credentials() {
 
   print_and_log "Verifying that Technet credentials are OK ..."
 
-  local url=http://technet.escenic.com
+  local url=http://maven.escenic.com
   local notok=$(
     is_unauthorized_to_access_url \
       ${technet_user} \

--- a/usr/share/escenic/ece-scripts/common-bashing.sh
+++ b/usr/share/escenic/ece-scripts/common-bashing.sh
@@ -588,3 +588,16 @@ function common_bashing_user_cancelled_hook() {
 function lowercase() {
   echo "$@" | tr [A-Z] [a-z]
 }
+
+### pretty_print_xml
+## Pretty prints the passed XML file
+##
+## $1 :: xml file
+function pretty_print_xml() {
+  local file=$1
+  local tmp_file=
+  tmp_file=$(mktemp)
+
+  xmllint --format "${file}" > "${tmp_file}"
+  run mv "${tmp_file}" "${file}"
+}

--- a/usr/share/escenic/ece-scripts/common-bashing.sh
+++ b/usr/share/escenic/ece-scripts/common-bashing.sh
@@ -311,8 +311,6 @@ function get_base_dir_from_bundle() {
         done
     fi
 
-    debug "get_base_dir_from_bundle file_name="$file_name $1
-
     echo $file_name
 }
 

--- a/usr/share/escenic/ece-scripts/common-os.sh
+++ b/usr/share/escenic/ece-scripts/common-os.sh
@@ -8,7 +8,7 @@
 common_bashing_is_loaded > /dev/null 2>&1 || source $(pwd)/common-bashing.sh
 
 ## Only used if the Tomcat download mirror couldn't be determined
-fallback_tomcat_url="http://apache.uib.no/tomcat/tomcat-7/v7.0.62/bin/apache-tomcat-7.0.62.tar.gz"
+fallback_tomcat_url="http://apache.uib.no/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz"
 
 # Can be used like this:
 # common_io_os_loaded 2>/dev/null || source common-os.sh

--- a/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
@@ -526,9 +526,9 @@ EOF
    print_and_log "Finished adding solr configuration for search"
    print_and_log "Started adding context configuration for indexer-webapp-presentation"
  
-     mkdir -p $tomcat_base/conf/Catalina/localhost/
+   mkdir -p $tomcat_base/conf/Catalina/localhost/
 
-     cat >> $tomcat_base/conf/Catalina/localhost/indexer-webapp-presentation.xml <<EOF
+   cat > $tomcat_base/conf/Catalina/localhost/indexer-webapp-presentation.xml <<EOF
     <Context docBase="$\\{catalina.base}/webapps/indexer-webapp">
       <Environment name="escenic/solr-base-uri" value="http://${search_host}:${solr_port}/solr/presentation/" type="java.lang.String" override="true"/>
       <Environment name="escenic/indexer-webservice" value="${presentation_indexer_ws_uri}" type="java.lang.String" override="true"/>
@@ -537,6 +537,7 @@ EOF
       <Environment name="escenic/failing-documents-storage-file" value="$escenic_data_dir/engine/failures-presentation.index" type="java.lang.String" override="true"/>
    </Context>
 EOF
+   pretty_print_xml $tomcat_base/conf/Catalina/localhost/indexer-webapp-presentation.xml
    print_and_log "Finished adding context for indexer-webapp-presentation"
 
   elif [ $install_profile_number -eq $PROFILE_ANALYSIS_SERVER ]; then
@@ -554,6 +555,7 @@ EOF
        $tomcat_base/conf/context.xml
   fi
 
+  pretty_print_xml $tomcat_base/conf/context.xml
   set_up_logging
 }
 

--- a/usr/share/escenic/ece-scripts/ece-install.d/content-engine.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/content-engine.sh
@@ -739,7 +739,7 @@ function install_ece_third_party_packages
       local version=$(lsb_release -s -r | sed "s#\.##g")
     fi
 
-    if [ $(has_oracle_java_installed) -eq 0 ]; then
+    if [ "$(has_oracle_java_installed)" -eq 0 ]; then
       install_oracle_java
     fi
 

--- a/usr/share/escenic/ece-scripts/ece-install.d/content-engine.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/content-engine.sh
@@ -320,7 +320,7 @@ function set_up_engine_and_plugins() {
     verify_that_archive_is_ok $download_dir/$file
 
     if [ $(echo $file | \
-      grep -E "^engine-[0-9]|^engine-trunk-SNAPSHOT|^engine-dist" | \
+      grep -E "^engine-[0-9]|^engine-trunk-SNAPSHOT|^engine-develop-SNAPSHOT|^engine-dist" | \
       wc -l) -gt 0 ]; then
       engine_dir=$(get_base_dir_from_bundle $download_dir/$file)
       engine_file=$file

--- a/usr/share/escenic/ece-scripts/ece-install.d/search-server.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/search-server.sh
@@ -1,16 +1,28 @@
 # ece-install module for installing the search server
 
+solr_download_url=http://apache.uib.no/lucene/solr/6.0.0/solr-6.0.0.zip
+
+## Since solr itself talks about SOLR_HOME as where it has its data
+## files (solr_data_dir might have been a more suitable name), we
+## cannot use solr_home as we e.g. use java_home, but instead use
+## this:
+solr_dir=/opt/solr
+
 function install_search_server() {
   print_and_log "Installing a search server on $HOSTNAME ..."
   type=search
   install_ece_instance "search1" 0
-  
-  multicore_solr_setup 
+
+  if [ ${fai_search_legacy-0} -eq 0 ]; then
+    set_up_solr
+  else
+    multicore_solr_setup_pre_ece6
+  fi
   assemble_deploy_and_restart_type
   leave_search_server_trail
 }
 
-function multicore_solr_setup(){
+function multicore_solr_setup_pre_ece6(){
   run_hook set_up_solr.preinst
 
   print_and_log "Setting up  Multicore Solr ..."
@@ -69,7 +81,7 @@ function multicore_solr_setup(){
 
   make_dir presentation/conf
   make_dir presentation/data/index
-  chown -R escenic:escenic presentation/data/
+  run chown -R ${ece_user}:${ece_group} presentation/data/
   run cp -r $escenic_conf_dir/solr/*  presentation/conf/
 
   run xmlstarlet ed -L -s //config -t elem -n DataTMP -v "$escenic_data_dir/solr/presentation/data" \
@@ -89,11 +101,85 @@ function multicore_solr_setup(){
 
 }
 
+function download_and_install_solr() {
+  local file=
+  local solr_base_dir=
+
+  solr_base_dir=$(basename ${solr_download_url} .zip)
+  if [ -e "/opt/${solr_base_dir}" ]; then
+    print_and_log "Solr dir, /opt/${solr_base_dir}, already exists, leaving it be."
+    return
+  fi
+
+  print "Downloading Solr from ${solr_download_url} ..."
+  download_uri_target_to_dir "${solr_download_url}" "${download_dir}"
+
+  file="${download_dir}"/$(basename ${solr_download_url})
+  run unzip -q "${file}" -d /opt
+  run chown -R "${ece_user}":"${ece_group}" "/opt/${solr_base_dir}"
+
+  if [ ! -h ${solr_dir} ]; then
+    run ln -s "/opt/${solr_base_dir}" ${solr_dir}
+  fi
+}
+
+function create_global_solr_configuration() {
+  local file=/etc/default/solr.in.sh
+  if [ -e ${file} ]; then
+    print_and_log "${file} already exists, not touching it"
+  else
+    print "Creating global solr config in ${file} ..."
+    run mv ${solr_dir}/bin/solr.in.sh "${file}"
+    cat >> ${file} <<EOF
+## Added by $(basename $0) @ $(date)
+SOLR_HOME=${escenic_data_dir/solr}
+SOLR_LOGS_DIR=${escenic_log_dir}
+SOLR_PID_DIR=${escenic_run_dir}
+EOF
+  fi
+}
+
+function setup_solr_init_d_script() {
+  local init_d_file=/etc/init.d/solr
+  if [ -e "${init_d_file}" ]; then
+    print_and_log "${init_d_file} already exists, keeping my hands off"
+    return
+  fi
+
+  print_and_log "Setting up init.d script: ${init_d_file}"
+  run mv "${solr_dir}/bin/init.d/solr" "${init_d_file}"
+  run sed -i "s#RUNAS=\"solr\"#RUNAS=\"${ece_user}\"#" "${init_d_file}"
+  run chmod 755 "${init_d_file}"
+
+  if [ "${on_debian_or_derivative}" -eq 1 ]; then
+    print_and_log "Adding the solr init.d script to the default run levels ..."
+    run update-rc.d solr defaults 35
+  elif [ "${on_redhat_or_derivative}" -eq 1 ]; then
+    print_and_log "Adding the solr init.d script to the default run levels ..."
+    run chkconfig --level 35 solr on
+  fi
+}
+
+function start_solr() {
+  run /etc/init.d/solr start
+}
+
 function set_up_solr() {
   run_hook set_up_solr.preinst
-  
+
+  local solr_core_list="
+    editorial
+    presentation
+  "
+
   print_and_log "Setting up Solr ..."
+  download_and_install_solr
+  create_global_solr_configuration
+  setup_solr_init_d_script
+
   if [ ! -d $escenic_conf_dir/solr ]; then
+    make_dir "$escenic_conf_dir/solr"
+
     if [ $(is_using_conf_archive) -eq 1 ]; then
       print_and_log "Using the supplied Solr configuration from" \
         "bundle: $ece_instance_conf_archive"
@@ -109,45 +195,78 @@ function set_up_solr() {
 
       run cd $a_tmp_dir
       run tar xzf $(basename $ece_instance_conf_archive) engine/solr/conf
-      run cp -r engine/solr/conf $escenic_conf_dir/solr
 
-      run rm -r $a_tmp_dir
+      for solr_core in ${solr_core_list}; do
+        run cp -r engine/solr/conf "$escenic_conf_dir/solr/${solr_core}"
+      done
+
+      run rm -r "${a_tmp_dir}"
     else
       print_and_log "Installing default Solr conf shipped with ECE ..."
-      run cp -r $escenic_root_dir/engine/solr/conf $escenic_conf_dir/solr
-      
-      # ECE 5.6 has one additional configuration file!
-      if [ -e $escenic_root_dir/engine/solr/solr.xml ]; then
-        run cp -r $escenic_root_dir/engine/solr/solr.xml $escenic_conf_dir/. 
-      fi
 
+      for solr_core in ${solr_core_list}; do
+        run cp -r "$escenic_root_dir/engine/solr/conf" "$escenic_conf_dir/solr/${solr_core}"
+      done
     fi
   else
     print_and_log "$escenic_conf_dir/solr already exists, not touching it."
   fi
 
-  make_dir $escenic_data_dir/solr/
-  run cd $escenic_data_dir/solr/
-  if  [ ! -h conf ]; then
-    run ln -s $escenic_conf_dir/solr conf
-  fi
-
-  # ECE 5.6 has one additional configuration file!
-  if  [ ! -h solr.xml ]; then
-    if [ -e $escenic_conf_dir/solr.xml ]; then
-      run ln -s $escenic_conf_dir/solr.xml solr.xml
-    fi
-  fi
-
-  local editorial_search_instance=${fai_search_for_editor-0}
-  local file=$escenic_conf_dir/solr/solrconfig.xml
-  if [ $editorial_search_instance -eq 1 ]; then
-    run sed -i "s#<maxTime>[0-9]*</maxTime>#<maxTime>5000</maxTime>#g" $file
+  local solr_xml="${escenic_data_dir}/solr.xml"
+  if [ -f "${solr_xml}" ]; then
+    print_and_log "${escenic_conf_dir}/solr.xml already exists, not touching it."
   else
-    run sed -i "s#<maxTime>[0-9]*</maxTime>#<maxTime>3000</maxTime>#g" $file
+    local target_solr_xml=/etc/escenic/solr.xml
+    print_and_log "Setting up solr.xml in ${target_solr_xml}"
+    run cp ${solr_dir}/server/solr/solr.xml "${target_solr_xml}"
+    run ln -s "${target_solr_xml}" "${escenic_data_dir}/solr.xml"
   fi
 
+  for solr_core in ${solr_core_list}; do
+    make_dir "$escenic_data_dir/solr/${solr_core}"
+    run cd "$escenic_data_dir/solr/${solr_core}"
+    if  [ ! -h conf ]; then
+      run ln -s "$escenic_conf_dir/solr/${solr_core}" conf
+    fi
+
+    create_solr_core_descriptor "${solr_core}"
+
+    ## backwards compatible: respect editorial_search_instance
+    local editorial_search_instance=${fai_search_for_editor-0}
+
+    if [ ${editorial_search_instance} -eq 0 ]; then
+      if [[ "editorial" == "${solr_core}" ]]; then
+        editorial_search_instance=1
+      fi
+    fi
+    local file=$escenic_conf_dir/solr/${solr_core}/solrconfig.xml
+    if [ ${editorial_search_instance} -eq 1 ]; then
+      run sed -i "s#<maxTime>[0-9]*</maxTime>#<maxTime>5000</maxTime>#g" $file
+    else
+      run sed -i "s#<maxTime>[0-9]*</maxTime>#<maxTime>3000</maxTime>#g" $file
+    fi
+  done
+
+  run chown -R "${ece_user}:${ece_group}" "${escenic_data_dir}/solr"
+  start_solr
   run_hook set_up_solr.postinst
+}
+
+## $1 :: solr core name
+function create_solr_core_descriptor() {
+  local solr_core=$1
+
+  ## Can't be in the conf directory as solr will then try to prepend
+  ## conf.
+  local core_descriptor="${escenic_data_dir}/solr/${solr_core}/core.properties"
+  print_and_log "Creating core descirptor: ${core_descriptor}"
+  cat > ${core_descriptor} <<EOF
+## generated by $(basename $0) @ $(date)
+name=${solr_core}
+config=solrconfig.xml
+schema=schema.xml
+dataDir=data
+EOF
 }
 
 function leave_search_server_trail() {


### PR DESCRIPTION
VOSA-229 ece-install now installs multi core Solr 6 

- requires ECE 6/develop branch
- using `ece-install` using with ECE 5.7 must set `fai_search_legacy=1`
- a number of bugfixes
- some updates with regards to vizrt -> escenic, downlists++