### PR TITLE
ece deploy --file now caches EAR file like it does with --uri

### DIFF
--- a/usr/share/escenic/ece-scripts/ece.d/deploy.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/deploy.sh
@@ -73,8 +73,8 @@ function deploy() {
       print_and_log "If found a healthy $ear locally so I will not fetch it again."
     elif [ -f "$file" ]; then
       print_and_log " Found a local ear file $file"
-      log "Creating a symlink of the file $file to $cache_dir"
-      run ln -s $file $ear
+      log "Copying it to to $cache_dir"
+      run cp "${file}" "${cache_dir}"
     else
       # wget_auth is needed for download_uri_target_to_dir
       wget_auth=$wget_builder_auth


### PR DESCRIPTION
When running 'ece deploy --file <file>', a symlink to the file was
created. However, this defies the point of the cache directory
somewhat, since the cache dir is for providing data that the ece
command can re-use on later runs.

When the file in /var/cache/escenic is only a symlink, there's no
guarantee that this file can be re-used. Moreover, since this file
often resides in /tmp, it will be deleted once the machine is
restarted.

This change copies the EAR file to the cache directory, making its
behaviour consistent with what happens when ece deploy is used with an
EAR residing on a remote machine.