### PR TITLE
Tell the JVM to use explicit encoding everywhere (UTF-8)

### DIFF
--- a/etc/escenic/ece.conf
+++ b/etc/escenic/ece.conf
@@ -203,6 +203,12 @@ jvm_connection_settings="
 "
 
 ######################################################################
+# Tell the JVM to use this encoding everywhere (in stead of falling
+# back to the system default).
+######################################################################
+jvm_encoding=UTF-8
+
+######################################################################
 # Java will use IPv6 if it's available on the OS. This however, can
 # cause problems with applications that insists on using IPv4
 # sockets.


### PR DESCRIPTION
- in stead of falling back to the system default, leading to
  unpredictable results.

- UTF-8 chosen as the default as it's a Unicode encoding that works
  well for everything. Can be overriden in ece-<instance>.conf

- this value is applied to these JVM parameters:

      sun.jnu.encoding
      file.encoding