### PR TITLE
VOSA-238: Changed the way we have checked supported Debian distributi…

### DIFF
--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -273,10 +273,10 @@ function install_common_os_packages()
   # ther systems through git.
   if [ $on_debian_or_derivative -eq 1 ]; then
     if [ ${fai_offline_mode-0} -eq 0 ]; then
-      curl -s http://apt.vizrt.com/archive.key 2>> $log | \
+      curl -s http://apt.escenic.com/archive.key 2>> $log | \
         apt-key add - 1>> $log 2>> $log
       local package_pool=${fai_apt_vizrt_pool-unstable}
-      add_apt_source "deb http://apt.vizrt.com ${package_pool} main"
+      add_apt_source "deb http://apt.escenic.com ${package_pool} main"
       run apt-get update
     fi
     install_packages_if_missing escenic-common-scripts

--- a/usr/share/doc/escenic/ece-install-guide.org
+++ b/usr/share/doc/escenic/ece-install-guide.org
@@ -146,12 +146,12 @@ is as follows:
       profile (see Run ece-install).
 
 ** <<<Get ece-install>>>
-On Debian based systems, such as Ubuntu, you can use the [[http://apt.vizrt.com][Vizrt APT
+On Debian based systems, such as Ubuntu, you can use the [[http://apt.escenic.com][Escenic APT
 repository]] and install the package *escenic-content-engine-installer*
 to get the *ece-install* command.
 
 On RedHat based systems, such as CentOS, you can use the RPMs
-available from http://yum.vizrt.com/rpm and install the RPM
+available from http://yum.escenic.com/rpm and install the RPM
 *escenic-common-scripts* and *escenic-content-engine-installer* to
 get the *ece-install* command.
 
@@ -159,7 +159,7 @@ If you have any problems installing using the DEB or RPM packages, or
 if you're system is neither Debian nor RedHat based, you can also
 download a ZIP archive of all the *ece-scripts*, which *ece-install*
 is a part of, here:
-https://github.com/vizrt/ece-scripts/zipball/master
+https://github.com/escenic/ece-scripts/zipball/master
 
 ** <<<Become Root>>>
 You must be the root user to run *ece-install*. If you try to run it as
@@ -1083,7 +1083,7 @@ the *ece-install.conf*:
 - *fai\_analysis\_stop\_and\_clear* :: After installation, stop the
      instances and clear its work & log files. Default is 0.
 
-- *fai\_apt\_vizrt\_pool* :: Which package pool in the Vizrt APT to
+- *fai\_apt\_escenic\_pool* :: Which package pool in the Escenic APT to
      install package from.. Default is stable.
 
 - *fai\_cache\_backends* :: Space separated, e.g. "app1:8080
@@ -1723,7 +1723,7 @@ main executable:
 *ece-install* started out as a purely interactive command, where the
 user was prompted for all the choices on what to install (most of
 which he/she could just hit ENTER to complete). Once this the
-interactive command was shown to customers and Vizrt employees, the
+interactive command was shown to customers and Escenic employees, the
 need for a fully automatic version became apparent and *ece-install*
 got the *fai_enabled* parameter to make the switch.
 
@@ -1753,7 +1753,7 @@ high performance. In the middle of 2011, Torstein Krause Johansen set
 out to remedy this and created *ece-install* as a personal side
 project.
 
-In February 2012, he joined the Vizrt Online SaaS team and was allowed
+In February 2012, he joined the Escenic Online SaaS team and was allowed
 to work on *ece-install* full time. The command has since then been
 used to install several full scale production environments, as well as
 being used for full scale automatic integration tests, development
@@ -1763,9 +1763,9 @@ the preferred way of installing new Escenic systems.
 From February 2013, it has been maintained by Erik Mogensen.
 
 * BUGS
-Report any bugs found on https://github.com/vizrt/ece-scripts/issues.
+Report any bugs found on https://github.com/escenic/ece-scripts/issues.
 and be sure to check
-https://github.com/vizrt/ece-scripts/known-issues.org before
+https://github.com/escenic/ece-scripts/known-issues.org before
 using *ece-install*.
 
 * SEE ALSO

--- a/usr/share/escenic/ece-scripts/ece-install.d/database.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/database.sh
@@ -18,7 +18,7 @@ function get_percona_repo_url() {
 
 function get_mariadb_repo_url() {
   local distributor=$(lsb_release -i -s | tr '[A-Z]' '[a-z]')
-  echo "http://ftp.heanet.ie/mirrors/mariadb/repo/5.5/$distributor/dists/"
+  echo "http://ftp.heanet.ie/mirrors/mariadb/repo/5.5/${distributor}/dists/"
 }
 
 function set_up_mariadb_yum_repo() {
@@ -32,7 +32,7 @@ function set_up_mariadb_yum_repo() {
       arch=x86
     fi
     if [ $distributor = "redhatenterpriseserver" ]; then
-      $distributor=rhel
+      distributor=rhel
     fi
     local yum_url=http://yum.mariadb.org/5.5/${distributor}${release}-${arch}
     cat > $maria_db_repo <<EOF
@@ -72,17 +72,20 @@ function is_supported() {
     else
         repo_url=$(get_percona_repo_url)
     fi
-    if [ "$(get_http_response_code "$repo_url$code_name/")" == "200" ]; then
+    if [ "$(get_http_response_code "${repo_url}${code_name}/")" == "200" ]; then
         supported_code_name=0
     fi
     return $supported_code_name
 }
 
-function get_http_response_code(){
+# This function will curl the repo url and follow if there is any redirect
+# Then take the last occurance of HTTP and find the status code 
+function get_http_response_code() {
     local url=$1
-    curl -I -s $url | \
+    curl -I -L -s ${url} | \
         grep HTTP | \
-        cut -d ' ' -f2
+        tail -1 | \
+        cut -d ' ' -f2        
 }
 
 function add_gpg_key() {

--- a/usr/share/escenic/ece-scripts/ece-install.d/database.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/database.sh
@@ -11,21 +11,14 @@ fi
 percona_ubuntu_gpg_key=1C4CBDCDCD2EFD2A
 mariadb_ubuntu_gpg_key=CBCB082A1BB943DB
 
-function get_ubuntu_supported_list() {
-  local url=$1
-  curl -s $url | \
-      html2 | \
-      sed -n '/\/a\/@href=[A-Za-z0-9]*\/$/s/.*=//p' | \
-      sed -n '/\/$/s/\/$//p'
+
+function get_percona_repo_url() {
+  echo  "http://repo.percona.com/apt/dists/"
 }
 
-function get_percona_supported_list() {
-  get_ubuntu_supported_list "http://repo.percona.com/apt/dists/"
-}
-
-function get_mariadb_supported_list() {
+function get_mariadb_repo_url() {
   local distributor=$(lsb_release -i -s | tr '[A-Z]' '[a-z]')
-  get_ubuntu_supported_list "http://ftp.heanet.ie/mirrors/mariadb/repo/5.5/$distributor/dists/"
+  echo "http://ftp.heanet.ie/mirrors/mariadb/repo/5.5/$distributor/dists/"
 }
 
 function set_up_mariadb_yum_repo() {
@@ -71,22 +64,25 @@ function set_up_redhat_repository_if_possible() {
 }
 
 function is_supported() {
-  local code_name=$1
-  local supported_code_name=1
-  local supported_list=""
-
-  if [ $db_vendor = "mariadb" ]; then
-    supported_list=$(get_mariadb_supported_list)
-  else
-    supported_list=$(get_percona_supported_list)
-  fi
-
-  for el in $supported_list; do
-    if [[ $code_name == $el ]]; then
-      supported_code_name=0
+    local code_name=$1
+    local supported_code_name=1
+    local repo_url=""
+    if [[ $db_vendor == "mariadb" ]]; then
+        repo_url=$(get_mariadb_repo_url)
+    else
+        repo_url=$(get_percona_repo_url)
     fi
-  done
-  return $supported_code_name
+    if [ "$(get_http_response_code "$repo_url$code_name/")" == "200" ]; then
+        supported_code_name=0
+    fi
+    return $supported_code_name
+}
+
+function get_http_response_code(){
+    local url=$1
+    curl -I -s $url | \
+        grep HTTP | \
+        cut -d ' ' -f2
 }
 
 function add_gpg_key() {

--- a/usr/share/puppet/modules/vosa/templates/etc/apt/sources.list.d/vizrt.list.erb
+++ b/usr/share/puppet/modules/vosa/templates/etc/apt/sources.list.d/vizrt.list.erb
@@ -1,1 +1,1 @@
-deb http://<%= apt_vizrt_user %>:<%= apt_vizrt_password %>@apt.vizrt.com stable main
+deb http://<%= apt_vizrt_user %>:<%= apt_vizrt_password %>@apt.escenic.com stable main

--- a/usr/share/vizrt/vosa/generated-servers/skeleton-amazon/hooks/post-install-hook-install-ece-install.sh
+++ b/usr/share/vizrt/vosa/generated-servers/skeleton-amazon/hooks/post-install-hook-install-ece-install.sh
@@ -2,11 +2,11 @@
 
 echo "--- START : post install hook - install ece install ---"
 
-# add archive key for apt.vizrt.com
-curl -s http://apt.vizrt.com/archive.key | ssh -F $2/ssh.conf guest 'sudo apt-key add -'
+# add archive key for apt.escenic.com
+curl -s http://apt.escenic.com/archive.key | ssh -F $2/ssh.conf guest 'sudo apt-key add -'
 
 # add repo to sources list
-echo "deb http://apt.vizrt.com unstable main" | ssh -F $2/ssh.conf guest 'sudo tee > /dev/null /etc/apt/sources.list.d/vizrt.list'
+echo "deb http://apt.escenic.com unstable main" | ssh -F $2/ssh.conf guest 'sudo tee > /dev/null /etc/apt/sources.list.d/vizrt.list'
 
 # install escenic scripts
 ssh -F $2/ssh.conf guest 'sudo apt-get update && sudo apt-get -y install escenic-content-engine-installer'

--- a/usr/share/vizrt/vosa/generated-servers/skeleton-dev/hooks/post-install-hook-add-vizrt-repo.sh
+++ b/usr/share/vizrt/vosa/generated-servers/skeleton-dev/hooks/post-install-hook-add-vizrt-repo.sh
@@ -2,11 +2,11 @@
 
 echo "--- START : post install hook - add vizrt repo ---"
 
-# add archive key for apt.vizrt.com
-curl -s http://apt.vizrt.com/archive.key | ssh -F $2/ssh.conf guest 'sudo apt-key add -'
+# add archive key for apt.escenic.com
+curl -s http://apt.escenic.com/archive.key | ssh -F $2/ssh.conf guest 'sudo apt-key add -'
 
 # add repo to sources list
-echo "deb http://apt.vizrt.com unstable main" | ssh -F $2/ssh.conf guest 'sudo tee > /dev/null /etc/apt/sources.list.d/vizrt.list'
+echo "deb http://apt.escenic.com unstable main" | ssh -F $2/ssh.conf guest 'sudo tee > /dev/null /etc/apt/sources.list.d/escenic.list'
 
 # update package lists
 ssh -F $2/ssh.conf guest 'sudo apt-get update'

--- a/usr/share/vizrt/vosa/generated-servers/skeleton-dev/hooks/post-install-hook-install-and-apply-spore.sh.tmpl
+++ b/usr/share/vizrt/vosa/generated-servers/skeleton-dev/hooks/post-install-hook-install-and-apply-spore.sh.tmpl
@@ -3,7 +3,7 @@
 echo "--- START : post install hook - install and apply spore ---"
 
 # import spores.key
-ssh -F \$2/ssh.conf root@guest 'curl http://apt.vizrt.com/spores.key | gpg --import'
+ssh -F \$2/ssh.conf root@guest 'curl http://apt.escenic.com/spores.key | gpg --import'
 
 # install spore
 ssh -F \$2/ssh.conf root@guest 'apt-get install spore'

--- a/usr/share/vizrt/vosa/post-install-hooks/add-vizrt-apt-repo.sh
+++ b/usr/share/vizrt/vosa/post-install-hooks/add-vizrt-apt-repo.sh
@@ -1,11 +1,11 @@
 #! /usr/bin/env bash
 
 ## Adds the Vizrt APT repository
-echo deb http://apt.vizrt.com unstable main | \
-  ssh -F $2/ssh.conf guest sudo tee /etc/apt/sources.list.d/apt-vizrt-com.list \
+echo deb http://apt.escenic.com unstable main | \
+  ssh -F $2/ssh.conf guest sudo tee /etc/apt/sources.list.d/apt.escenic.com.list \
   > /dev/null
 
-curl -s http://apt.vizrt.com/archive.key | \
+curl -s http://apt.escenic.com/archive.key | \
   ssh -F $2/ssh.conf guest sudo apt-key add - \
   > /dev/null
 

--- a/usr/share/vizrt/vosa/post-install-hooks/run-sdp-bootstrapper.sh
+++ b/usr/share/vizrt/vosa/post-install-hooks/run-sdp-bootstrapper.sh
@@ -32,8 +32,8 @@ fi
 guest="ssh -F $2/ssh.conf root@guest"
 
 if $guest [ -d /etc/apt/sources.list.d ] ; then
-  $guest tee /etc/apt/sources.list.d/vizrt.list <<EOF
-deb http://apt.vizrt.com/ akita main non-free
+  $guest tee /etc/apt/sources.list.d/escenic.list <<EOF
+deb http://apt.escenic.com/ unstable main non-free
 EOF
 
   $guest tee /etc/apt/preferences.d/30prefer-vizrt-akita-packages <<EOF


### PR DESCRIPTION
Changed the way we have checked supported Debian distribution for database providers.
  - Before we used  html scraping to find the code name of the distribution which actually causing problem as Percona now uses gzip encoding to server their repo.
  - Mariadb repo is as before which is with any encoding. So some special handle needed to be done for Percona.
  - Now the it will check http status code by hitting the actual distribution repo url. If it gives 200, the return code will be 0 else 1.