### PR TITLE
VOSA-242 escenic-content-engine-scripts now includes /etc/escenic/ece.conf & /etc/default/ece

### DIFF
--- a/usr/share/escenic/package-scripts/create-packages
+++ b/usr/share/escenic/package-scripts/create-packages
@@ -137,7 +137,7 @@ function set_up_escenic-content-engine-scripts() {
   make_dir $doc_dir
   make_dir $target_dir/usr/share/escenic/ece-scripts
   make_dir $target_dir/usr/{bin,sbin,share/doc}
-  make_dir $target_dir/{etc,usr,/etc/default}
+  make_dir $target_dir/{etc/escenic,usr,/etc/default}
 
   # bin
   local bin_list='ece ece-import'
@@ -153,9 +153,8 @@ function set_up_escenic-content-engine-scripts() {
   # conf
   run cp ../../../../etc/bash_completion.d/{ece,ece-import,ece-deploy} \
     $target_dir/etc/bash_completion.d
-  # we don't include /etc/default/ece as this file often is also
-  # included in the conf packages.
-  # run cp -r ../../../../etc/default/ece $target_dir/etc/default/
+  run cp -r ../../../../etc/default/ece $target_dir/etc/default/
+  run cp -r ../../../../etc/escenic/ece.conf $target_dir/etc/escenic/
   run cp -r ../../../../etc/init.d/ece $target_dir/etc/init.d/
 
   # doc


### PR DESCRIPTION
…t needs

Before, escenic-content-engine-scripts didn't include two files that
were crucial:

```
/etc/escenic/ece.conf     # needed by /usr/bin/ece
/etc/default/ece          # needed by /etc/init.d/ece
```

The reason why we excluded can be read in
faeee24ec9ba7c4edc86905dba420b87f8867db6, that these were included in
the vosa-conf packages.

However, this severely reduced the usefulness of the package. This
meant that users had to read documentation to know that they had to
manually copy these files from an example directory to the right
locations to make /usr/bin/ece and /etc/init.d/ece work.

Furthermore, it made it impossible to get new additions to these files
when apt-get upgrading the package as these files are manually
copied. If we changed /usr/bin/ece to use a new default value in
/etc/escenic/ece.conf, the user would not get it and the command will
fail when upgrading the package.

What needs to be changed in vosa-conf DEB packages:

0) These two files must be removed from the vosa-conf packages

1) All changes from the default ece.conf needs to be put in
   ece-<instance>.conf. A file that we already have for most/all
   customers since we always run two instances on each machine (one
   ECE, one search).  Changes that the cloud tools does to
   /etc/default/ece will be kept when apt-get upgrading to a newer
   version of escenic-content-engine-scripts (that's standard
   dpkg/deb/apt functionality).