### PR TITLE
Bug fix in 'ece repackage': consider installed webservice webapps first

### DIFF
--- a/usr/local/src/unit-tests/ece-repackage-test.sh
+++ b/usr/local/src/unit-tests/ece-repackage-test.sh
@@ -3,10 +3,26 @@
 # by torstein@escenic.com
 
 test_can_get_base_name_of_develop_snapshot_dependency() {
-  local file=base-develop-SNAPSHOT.jar
+  local file=/tmp/var/base-develop-SNAPSHOT.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
+  assertEquals "${expected}" "${actual}"
+}
+
+test_can_get_base_name_jar_pack_gz() {
+  local file=/tmp/var/base-develop-SNAPSHOT.jar.pack.gz
+  local expected=base
+  local actual=
+  actual=$(get_file_base ${file} gz)
+  assertEquals "${expected}" "${actual}"
+}
+
+test_can_get_base_name_of_develop_timestamp_dependency() {
+  local file=base-develop-20170126.051354-372.jar
+  local expected=base
+  local actual=
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -14,7 +30,7 @@ test_can_get_base_name_of_trunk_snapshot_dependency() {
   local file=base-trunk-SNAPSHOT.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -22,7 +38,7 @@ test_can_get_base_name_of_snapshot_dependency() {
   local file=base-2.0-SNAPSHOT.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -30,7 +46,7 @@ test_can_get_base_name_of_regular_major_minor_dependency() {
   local file=base-2.0.1.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -38,7 +54,7 @@ test_can_get_base_name_of_date_stamp_version() {
   local file=relaxngDatatype-20020414.jar
   local expected=relaxngDatatype
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -46,7 +62,7 @@ test_can_get_base_name_of_regular_major_minor_dependency_with_build_number() {
   local file=base-2.0.1-23.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -54,19 +70,19 @@ test_can_get_base_name_of_alpha_dependency() {
   local file=base-2.0.4-alpha-2.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 
   file=base-2.0.4-beta-2.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 
   file=base-2.0.4-rc-2.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
@@ -74,33 +90,33 @@ test_can_get_base_name_of_alpha_dependency_semver() {
   local file=base-2.0.4-alpha.2.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 
   file=base-2.0.4-beta.2.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 
   file=base-2.0.4-rc.2.jar
   local expected=base
   local actual=
-  actual=$(get_file_base ${file} .jar)
+  actual=$(get_file_base ${file} jar)
   assertEquals "${expected}" "${actual}"
 }
 
 test_can_detect_that_escenic_admin_doesnt_need_patching() {
   local expected=1
   local actual=
-  should_patch_war "/path/to/escenic-admin.war" && actual=$? || actual=$?
+  should_patch_war_with_template_libs "/path/to/escenic-admin.war" && actual=$? || actual=$?
   assertEquals "${expected}" "${actual}"
 }
 
 test_can_detect_that_live_center_need_patching() {
   local expected=0
   local actual=
-  should_patch_war "/path/to/live-center.war" && actual=$? || actual=$?
+  should_patch_war_with_template_libs "/path/to/live-center.war" && actual=$? || actual=$?
   assertEquals "${expected}" "${actual}"
 }
 
@@ -192,6 +208,183 @@ test_can_merge_webservice_war_in_ear_replace_libraries_present_on_machine() {
                "${actual}"
 }
 
+## be sure that it uses the webservice.war install with the
+## escenic-content-engine-<version> as a basis.
+test_can_merge_webservice_war_include_all_files_in_package_war() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local ear_extract_tmp_dir=
+  ear_extract_tmp_dir=$(mktemp -d)
+  (cd "${ear_extract_tmp_dir}" && jar xf "${repackaged_ear}")
+
+  local expected=0
+  actual=$(unzip -v "${ear_extract_tmp_dir}/webservice.war" |
+             grep -c "engine-jersey-${ECE_VERSION_IN_EAR}")
+  assertEquals "Version of engine-jersey (lib in webservice.war) in EAR should be replaced with package version" \
+               "${expected}" \
+               "${actual}"
+
+  expected=1
+  actual=$(unzip -v "${ear_extract_tmp_dir}/webservice.war" |
+             grep -c "engine-jersey-${ECE_VERSION}")
+  assertEquals "Version of engine-jersey (lib in webservice.war) in EAR should be replaced with package version" \
+               "${expected}" \
+               "${actual}"
+
+  expected=1
+  actual=$(unzip -v "${ear_extract_tmp_dir}/webservice.war" |
+             grep -c "engine-servletsupport-${ECE_VERSION}")
+  assertEquals "Version of engine-servletsupport (template lib) in EAR should be replaced with package version" \
+               "${expected}" \
+               "${actual}"
+
+}
+
+## be sure that it uses the webservice.war install with the
+## escenic-content-engine-<version> as a basis.
+test_can_merge_webservice_war_replace_plugin_jars() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local ear_extract_tmp_dir=
+  ear_extract_tmp_dir=$(mktemp -d)
+  (cd "${ear_extract_tmp_dir}" && jar xf "${repackaged_ear}")
+
+  local expected=1
+  actual=$(unzip -v "${ear_extract_tmp_dir}/webservice.war" |
+             grep -c "plugin-webservice")
+  assertEquals "Should only be one plugin-webservice in webservice.war" \
+               "${expected}" \
+               "${actual}"
+  expected=1
+  local looking_for=${EAR_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB}-${PACKAGE_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB_VERSION}.jar
+  actual=$(unzip -v "${ear_extract_tmp_dir}/webservice.war" |
+             grep -c "${looking_for}")
+  assertEquals "Didn't find ${looking_for}" "${expected}" "${actual}"
+}
+
+test_can_merge_files_with_same_base_but_different_suffix() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+
+  unzip -q "${repackaged_ear}" webservice.war -d "${tmp_dir}"
+  local expected=2
+  local actual=
+  actual=$(unzip -v "${tmp_dir}/webservice.war" |
+             grep -c "${EAR_WEBSERVICE_WAR_FILE_BOTH_CSS_AND_PDF}")
+  assertEquals "${expected}" "${actual}"
+
+  expected=1
+  actual=$(unzip -v "${tmp_dir}/webservice.war" |
+             grep -c "${EAR_WEBSERVICE_WAR_FILE_BOTH_CSS_AND_PDF}.css")
+  assertEquals "${expected}" "${actual}"
+
+  expected=1
+  actual=$(unzip -v "${tmp_dir}/webservice.war" |
+             grep -c "${EAR_WEBSERVICE_WAR_FILE_BOTH_CSS_AND_PDF}.pdf")
+  assertEquals "${expected}" "${actual}"
+
+  rm -r "${tmp_dir}"
+}
+
+## <plugin>/webapps/*.war should get patched with ECE's template libs,
+## but not with template libs from other plugins.
+test_can_exclude_other_plugin_webapp_libs_when_patching_plugin_package_webapp() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+
+  unzip -q "${repackaged_ear}" "${EAR_PLUGIN2_WEBAPP}".war -d "${tmp_dir}"
+
+  local expected=0
+  local actual=
+  actual=$(unzip -v "${tmp_dir}/${EAR_PLUGIN2_WEBAPP}.war" |
+             grep -c "${EAR_PLUGIN_TEMPLATE_LIB}")
+  assertEquals "${expected}" "${actual}"
+}
+
+test_can_merge_webapp_extensions_index_jsp() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+  unzip -q "${repackaged_ear}" "webservice-extensions.war" -d "${tmp_dir}"
+
+  local expected=1
+  local actual=
+  actual=$(unzip -v "${tmp_dir}/webservice-extensions.war" |
+             grep -c "${WEBSERVICE_EXTENSION_INDEX_JSP_REL_DIR}/index.jsp")
+  assertEquals "${expected}" "${actual}"
+
+  expected=${WEBSERVICE_EXTENSION_INDEX_JSP_CONTENTS_PACKAGE}
+  unzip -q "${tmp_dir}/webservice-extensions.war" \
+        "${WEBSERVICE_EXTENSION_INDEX_JSP_REL_DIR}/index.jsp" \
+        -d "${tmp_dir}"
+  actual=$(cat "${tmp_dir}/${EAR_PLUGIN_NAME}/datasource/index.jsp")
+  assertEquals "${expected}" "${actual}"
+}
+
+test_can_merge_studio_pack_gz_files() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+
+  unzip -q "${repackaged_ear}" studio.war -d "${tmp_dir}"
+
+  local expected=0
+  local actual=
+
+  actual=$(unzip -v "${tmp_dir}/studio.war" |
+             grep -c "studio/lib/studio-core-${ECE_VERSION_IN_EAR}.jar.pack.gz")
+  assertEquals "Should merge CS library merged with correct version, no EAR version" \
+               "${expected}" \
+               "${actual}"
+
+  expected=1
+  actual=
+  actual=$(unzip -v "${tmp_dir}/studio.war" |
+             grep -c "studio/lib/studio-core-${ECE_VERSION}.jar.pack.gz")
+  assertEquals "Should merge CS library merged with correct version, include package version" \
+               "${expected}" \
+               "${actual}"
+}
+
+test_can_merge_studio_plugin_libaries_replace_version_ear() {
+  local repackaged_ear=
+  repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
+
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+
+  unzip -q "${repackaged_ear}" studio.war -d "${tmp_dir}"
+
+  local expected=0
+  local actual=
+
+  actual=$(unzip -v "${tmp_dir}/studio.war" |
+             grep -c "studio/plugin/${EAR_PLUGIN_NAME}/lib/${EAR_PLUGIN_NAME}-studio-${ECE_VERSION_IN_EAR}.jar")
+  assertEquals "Should merge CS plugin library correctly, not version in EAR." \
+               "${expected}" \
+               "${actual}"
+
+  expected=1
+  actual=
+  actual=$(unzip -v "${tmp_dir}/studio.war" |
+             grep -c "studio/plugin/${EAR_PLUGIN_NAME}/lib/${EAR_PLUGIN_NAME}-studio-${ECE_VERSION}.jar")
+  assertEquals "Should merge CS plugin library correctly, package version." \
+               "${expected}" \
+               "${actual}"
+}
+
 test_can_repackage_ear_no_duplicates_in_lib() {
   local repackaged_ear=
   repackaged_ear=$(quiet=1 repackage "${ear}" | tail -1)
@@ -216,6 +409,7 @@ EOF
 
 get_ece_package_webapp_names() {
   cat <<EOF
+escenic-admin.war
 studio.war
 webservice.war
 webservice-extensions.war
@@ -238,22 +432,78 @@ create_ece_package_installation() {
     )
   done
 
+  # webservice.war
+  local webservice_war_tmp="${tmp_dir}/webservice_tmp"
+  mkdir -p "${webservice_war_tmp}/WEB-INF/lib"
+  touch "${webservice_war_tmp}/WEB-INF/lib/engine-jersey-${ECE_VERSION}.jar"
+  touch "${webservice_war_tmp}/WEB-INF/lib/engine-servletsupport-${ECE_VERSION}.jar"
+  touch "${webservice_war_tmp}/WEB-INF/lib/${EAR_WEBSERVICE_WAR_FILE_BOTH_CSS_AND_PDF}.pdf"
+  (cd "${webservice_war_tmp}" &&
+     zip -q -u -r "${ece_share_dir}/webapps/webservice.war" .)
+
+  # webservice-extensions.war
+  local webservice_extensions_war_tmp="${tmp_dir}/webservice_extensions_tmp"
+  mkdir -p "${webservice_extensions_war_tmp}/WEB-INF/lib"
+  touch "${webservice_extensions_war_tmp}/index.jsp"
+  (cd "${webservice_extensions_war_tmp}" &&
+     zip -q -u -r "${ece_share_dir}/webapps/webservice-extensions.war" .)
+
+  # studio.war
+  local studio_war_tmp="${tmp_dir}/studio_tmp"
+  mkdir -p "${studio_war_tmp}/studio/lib"
+  touch "${studio_war_tmp}/studio/lib/studio-core-${ECE_VERSION}.jar.pack.gz"
+  (cd "${studio_war_tmp}" &&
+     zip -q -u -r "${ece_share_dir}/webapps/studio.war" .)
+
+  # global lib
   local ece_lib_dir="${ece_share_dir}/lib"
   mkdir -p "${ece_lib_dir}"
   touch "${ece_lib_dir}/engine-core-${ECE_VERSION}.jar"
 
+  # template lib
   local ece_template_dir="${ece_share_dir}/template"
   mkdir -p "${ece_template_dir}"
   for el in $(get_ece_package_template_files); do
-    local dir="${ece_template_dir}/$(dirname "${el}")"
+    local dir=
+    dir="${ece_template_dir}/$(dirname "${el}")"
     mkdir -p "${dir}"
     # create jar
-    local jar="${dir}/$(basename "${el}")"
+    local jar=
+    jar="${dir}/$(basename "${el}")"
     local f_tmp_dir=
     f_tmp_dir=$(mktemp -d)
     (cd "${f_tmp_dir}" && jar cf "${jar}" .)
     rm -r "${f_tmp_dir}"
   done
+
+  # a plugin
+  # - with a JAR to be added to webservice.war
+  # - with a JAR to be added to publication webapps
+  # - with a JAR to be added to studio.war
+  # - with an index.jsp to be added to webservice-extensions.war
+  local plugin_share_dir="${USR_SHARE_DIR}/escenic-${EAR_PLUGIN_NAME}"
+  local plugin_template_web_inf_lib="${plugin_share_dir}/publication/webapp/WEB-INF/lib"
+  local plugin_web_inf_lib="${plugin_share_dir}/webservice/webapp/WEB-INF/lib"
+  mkdir -p "${plugin_web_inf_lib}"
+  mkdir -p "${plugin_template_web_inf_lib}"
+  touch "${plugin_web_inf_lib}/${EAR_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB}-${PACKAGE_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB_VERSION}.jar"
+  touch "${plugin_template_web_inf_lib}/${EAR_PLUGIN_TEMPLATE_LIB}.jar"
+  local plugin_studio_lib_dir="${plugin_share_dir}/studio/lib"
+  mkdir -p "${plugin_studio_lib_dir}"
+  touch "${plugin_studio_lib_dir}/${EAR_PLUGIN_NAME}-studio-${ECE_VERSION}.jar"
+  export PLUGIN_INDEX_JSP="${plugin_share_dir}/webservice-extensions/webapp/${WEBSERVICE_EXTENSION_INDEX_JSP_REL_DIR}/index.jsp"
+  mkdir -p "${PLUGIN_INDEX_JSP%/*}"
+  echo "${WEBSERVICE_EXTENSION_INDEX_JSP_CONTENTS_PACKAGE}" > "${PLUGIN_INDEX_JSP}"
+
+  # another plugin
+  # - with a JAR to be added to studio.war
+  plugin_share_dir="${USR_SHARE_DIR}/escenic-${EAR_PLUGIN2_NAME}"
+  plugin_webapps_dir="${plugin_share_dir}/webapps"
+  mkdir -p "${plugin_webapps_dir}"
+  local plugin_ws_tmp_dir=
+  plugin_ws_tmp_dir=$(mktemp -d)
+  (cd "${plugin_ws_tmp_dir}" && jar cf "${plugin_webapps_dir}/${EAR_PLUGIN2_WEBAPP}.war" .)
+  rm -r "${plugin_ws_tmp_dir}"
 }
 
 create_ear_that_will_be_repackaged() {
@@ -283,10 +533,33 @@ create_ear_that_will_be_repackaged() {
   touch "${war_tmp_dir}/${EAR_WEBSERVICE_WAR_EXTENSION_FILE}"
   mkdir -p "${war_tmp_dir}/WEB-INF/lib"
   touch "${war_tmp_dir}/WEB-INF/lib/engine-servletsupport-${ECE_VERSION_IN_EAR}.jar"
+  touch "${war_tmp_dir}/WEB-INF/lib/engine-jersey-${ECE_VERSION_IN_EAR}.jar"
+  touch "${war_tmp_dir}/WEB-INF/lib/${EAR_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB}-${EAR_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB_VERSION}.jar"
+  touch "${war_tmp_dir}/WEB-INF/lib/${EAR_WEBSERVICE_WAR_FILE_BOTH_CSS_AND_PDF}.css"
   (cd "${war_tmp_dir}" && jar cf "${war}" .)
   rm -r "${war_tmp_dir}"
 
-  ear="${tmp_dir}/${BASH_SOURCE[0]}.ear"
+  # create webservice-extensions.war
+  war_tmp_dir=$(mktemp -d)
+  local index_jsp_in_we_war="${war_tmp_dir}/${WEBSERVICE_EXTENSION_INDEX_JSP_REL_DIR}/index.jsp"
+  mkdir -p "${index_jsp_in_we_war%/*}"
+  echo "${WEBSERVICE_EXTENSION_INDEX_JSP_CONTENTS_EAR}" > "${index_jsp_in_we_war}"
+  (cd "${war_tmp_dir}" && jar cf "${ear_dir}/webservice-extensions.war" .)
+  rm -r "${war_tmp_dir}"
+
+  # create studio.war
+  war_tmp_dir=$(mktemp -d)
+  local studio_lib_dir="${war_tmp_dir}/studio/lib"
+  mkdir -p "${studio_lib_dir}"
+  touch "${studio_lib_dir}/studio-core-${ECE_VERSION_IN_EAR}.jar.pack.gz"
+  mkdir -p "${war_tmp_dir}/studio/plugin/${EAR_PLUGIN_NAME}/lib"
+  touch "${war_tmp_dir}/studio/plugin/${EAR_PLUGIN_NAME}/lib/${EAR_PLUGIN_NAME}-studio-${ECE_VERSION_IN_EAR}.jar"
+
+  war="${ear_dir}/studio.war"
+  (cd "${war_tmp_dir}" && jar cf "${war}" .)
+  rm -r "${war_tmp_dir}"
+
+  ear="${tmp_dir}/$(basename "$0").ear"
   (cd "${ear_dir}" && jar cf "${ear}" .)
 }
 
@@ -305,6 +578,21 @@ setUp() {
 
   ECE_VERSION=6.7.5
   ECE_VERSION_IN_EAR=6.2.0
+
+  EAR_PLUGIN_NAME=foo-some-plugin
+  EAR_PLUGIN2_NAME=bar-some-other-plugin
+  EAR_PLUGIN2_WEBAPP=${EAR_PLUGIN2_NAME}-ws
+
+  WEBSERVICE_EXTENSION_INDEX_JSP_REL_DIR=${EAR_PLUGIN_NAME}/datasource
+  WEBSERVICE_EXTENSION_INDEX_JSP_CONTENTS_PACKAGE="<h1>hello from package</h1>"
+  WEBSERVICE_EXTENSION_INDEX_JSP_CONTENTS_EAR="<h2>Hello from ear</h2>"
+
+  EAR_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB=${EAR_PLUGIN_NAME}-webservice-lib
+  EAR_PLUGIN_TEMPLATE_LIB=${EAR_PLUGIN_NAME}-presentation
+  EAR_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB_VERSION=1.2.3
+  EAR_WEBSERVICE_WAR_FILE_BOTH_CSS_AND_PDF=hello-world
+  PACKAGE_WEBSERVICE_WAR_PLUGIN_WEBSERVICE_LIB_VERSION=5.3.1
+
   create_ece_package_installation "${tmp_dir}"
   create_ear_that_will_be_repackaged "${tmp_dir}"
 }

--- a/usr/share/escenic/ece-scripts/common-bashing.sh
+++ b/usr/share/escenic/ece-scripts/common-bashing.sh
@@ -55,7 +55,7 @@ function get_id() {
 ## $@ :: as many strings as you want
 function debug() {
   if [ $debug -eq 1 ]; then
-    echo "[$(basename $0)-debug]" "$@"
+    echo "[${0##*/}-debug]" "$@"
   fi
 }
 

--- a/usr/share/escenic/ece-scripts/ece.d/repackage.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/repackage.sh
@@ -16,6 +16,10 @@ get_installed_packages_war_list() {
     done
 }
 
+get_installed_packages_war_name_list() {
+  get_installed_packages_war_list | sed 's#.*[/]##'
+}
+
 get_installed_packages_lib_list() {
   find "${USR_SHARE_DIR}/escenic-"* -maxdepth 1 -name "lib" -type d | \
     while read -r lib_dir; do
@@ -38,20 +42,29 @@ get_installed_packages_studio_list() {
        -name "studio" -type d
 }
 
-## $1 :: tmp dir with EAR contents
-copy_webapps_included_in_installed_packages_if_not_exists() {
-  local tmp_dir=$1
-  local war=
-  for war in $(get_installed_packages_war_list); do
-    local war_base=
-    war_base=$(basename "${war}")
-    if [[ ! -e "${tmp_dir}/${war_base}" ]]; then
-      run cp "${war}" "${tmp_dir}"
-    else
-      debug "EAR already has ${war_base}, will patch it"
-      # will be patched in overwrite_webapp_libs(), see main()
-    fi
-  done
+get_installed_package_webservice_war() {
+  find "${USR_SHARE_DIR}/escenic-content-engine-"* -maxdepth 2 \
+       -name "webservice.war" -type f
+}
+
+get_installed_package_studio_war() {
+  find "${USR_SHARE_DIR}/escenic-content-engine-"* -maxdepth 2 \
+       -name "studio.war" -type f
+}
+
+get_installed_package_webservice_extensions_war() {
+  find "${USR_SHARE_DIR}/escenic-content-engine-"* -maxdepth 2 \
+       -name "webservice-extensions.war" -type f
+}
+
+get_installed_package_content_engine_war_list() {
+  find "${USR_SHARE_DIR}/escenic-content-engine-"* -maxdepth 2 \
+       -name "*.war" -type f
+}
+
+get_installed_package_content_engine_war_name_list() {
+  get_installed_package_content_engine_war_list |
+    sed 's#.*[/]##'
 }
 
 ## Normalises the file name so that we can compare two JARs of
@@ -60,8 +73,22 @@ copy_webapps_included_in_installed_packages_if_not_exists() {
 ## $1 :: file name
 ## $2 :: suffix
 get_file_base() {
-  basename "$1" "$2" |
+  local file_name=$1
+  local suffix=${2:-}
+
+  file_name=${file_name##*/}
+
+  if [ -n "${suffix}" ]; then
+    file_name=${file_name//.${suffix}}
+  fi
+
+  # special handling of jar.pack.gz, the gz is removed in the above
+  # logic.
+  file_name=${file_name//jar.pack}
+
+  printf "%s\n" "${file_name}" |
     sed -r \
+        -e 's#-develop-[-\.0-9]+##' \
         -e 's#[-][0-9.-]+##' \
         -e 's#-trunk-SNAPSHOT##' \
         -e 's#-develop-SNAPSHOT##' \
@@ -82,7 +109,7 @@ remove_libs_included_in_installed_packages() {
     for ear_jar in "${tmp_dir}/lib/"*.jar; do
       ear_jar_base=$(get_file_base "${ear_jar}" jar)
       if [[ "${ear_jar_base}" == "${package_jar_base}" ]]; then
-        debug "Removing JAR in EAR, $(basename "${ear_jar}"),
+        debug "Removing JAR in EAR, ${ear_jar##*/},
                will be replaced with ${package_jar}"
         run rm "${ear_jar}"
       fi
@@ -103,16 +130,30 @@ copy_libs_included_in_installed_packages() {
 }
 
 ## $1 :: tmp dir with WAR contents
+## $2 :: base name of WAR file
 overwrite_webapp_libs_included_in_installed_packages() {
   local tmp_dir=$1
+  local war_name=$2
+
+  local is_a_package_war=0
+  is_a_package_war=$(
+    get_installed_packages_war_name_list |
+      grep -c -w "${war_name}" || true)
 
   local package_dir=
   for package_dir in "${USR_SHARE_DIR}/"*; do
     local template_lib_dir="${package_dir}/template/WEB-INF/lib"
-    if [ ! -d "${template_lib_dir}" ]; then
-      # ECE and its plugins put their publication specific libraries
-      # in different directory structures.
-      template_lib_dir="${package_dir}/publication/webapp/WEB-INF/lib"
+    if [[ ! -d "${template_lib_dir}" ]]; then
+
+      # Only patch the WAR with plugin template libraries if the WAR
+      # isn't a plugin webapp (e.g. poll-ws).
+      if [ "${is_a_package_war-0}" -eq 0 ]; then
+        # ECE and its plugins put their publication specific libraries
+        # in different directory structures. This is the location
+        # plugins use.
+        template_lib_dir="${package_dir}/publication/webapp/WEB-INF/lib"
+      fi
+
       if [ ! -d "${template_lib_dir}" ]; then
         continue
       fi
@@ -132,11 +173,10 @@ overwrite_webapp_libs_included_in_installed_packages() {
           if [[ "${pub_war_jar_base}" == "${package_jar_base}" ]]; then
             debug " -> Replacing ${pub_war_jar} with ${package_jar}"
             run rm "${pub_war_jar}"
-            run cp "${package_jar}" "$(dirname "${pub_war_jar}")"
+            run cp "${package_jar}" "${pub_war_jar%/*}/."
           else
             debug " -> ${pub_war} doesn't have ${package_jar}, adding it"
-            local dir=
-            dir="$(dirname "${pub_war_jar}")"
+            local dir="${pub_war_jar%/*}"
             make_dir "${dir}"
             run cp "${package_jar}" "${dir}/."
           fi
@@ -170,14 +210,12 @@ create_new_ear_in_dir() {
 }
 
 ## $1 :: war
-should_patch_war() {
+should_patch_war_with_template_libs() {
   local war=$1
-  local war_base=
-  war_base=$(basename "${war}")
+  local war_base=${war##*/}
 
   local -a should_not_be_patched=(
-    "escenic-admin.war"
-    "escenic.war"
+    $(get_installed_package_content_engine_war_name_list)
   )
 
   local el=
@@ -195,23 +233,21 @@ should_patch_war() {
 ## $1 :: the dir in which the extracted EAR resides
 overwrite_webapp_libs() {
   local dir=$1
-  local installed_package_war_list=
-  installed_package_war_list=$(get_installed_packages_war_list)
 
   find "${dir}" -name "*.war" | while read -r war; do
-    if ! should_patch_war "${war}"; then
+    if ! should_patch_war_with_template_libs "${war}"; then
       continue
     fi
-    local start=
     local tmp_dir=
     tmp_dir=$(mktemp -d)
 
-    log "Fixing $(basename "${war}"), extracting it to ${tmp_dir} ..."
-    run unzip -q "${war}" -d "${tmp_dir}"
-
+    local start=
     start=$(date +%s)
-    overwrite_webapp_libs_included_in_installed_packages "${tmp_dir}"
-    log "Fixing $(basename "${war}") took $(( $(date +%s) - start)) seconds ..."
+
+    run unzip -q "${war}" -d "${tmp_dir}"
+    overwrite_webapp_libs_included_in_installed_packages \
+      "${tmp_dir}" \
+      "${war##*/}"
 
     # to be sure it's prestine, we delete the old war
     run rm "${war}"
@@ -221,6 +257,7 @@ overwrite_webapp_libs() {
     )
 
     run rm -rf "${tmp_dir}"
+    log_profile "Fixing webapp libs for ${war##*/}" "${start}"
   done
 }
 
@@ -236,7 +273,7 @@ overwrite_webapp_libs() {
 ensure_ear_reference_and_lineage_sanity() {
   ## user passed a file or uri, that's easy.
   if [ -n "${file_or_uri}" ]; then
-    ear_name_or_hash=$(basename "${file_or_uri}")
+    ear_name_or_hash=${file_or_uri##*/}
     return
   fi
 
@@ -289,7 +326,7 @@ ensure_ear_reference_and_lineage_sanity() {
   elif [ -r "${default_cached_engine_ear}" ]; then
     print_and_log "Repackaging EAR ${default_cached_engine_ear} ... "
     file_or_uri=${default_cached_engine_ear}
-    ear_name_or_hash=$(basename "${default_cached_engine_ear}")
+    ear_name_or_hash=${default_cached_engine_ear##*/}
   else
     print_and_log "
       You must either specify an EAR to be repackaged
@@ -309,7 +346,7 @@ get_local_ear_reference() {
     export wget_auth=${wget_builder_auth-""}
 
     local file_name=
-    file_name=$(basename "${file_or_uri}")
+    file_name=${file_or_uri##*/}
 
     download_uri_target_to_dir "${file_or_uri}" "${cache_dir}" "${file_name}"
 
@@ -319,11 +356,12 @@ get_local_ear_reference() {
 
 ## $1 : WAR to update
 ## $2 : directories whose contents should be merged with that of the
-##      WAR
+##      WAR. If any of these contain the same JARs as the WAR has, the
+##      version in the directory will take precedence.
 merge_all_dirs_to_war() {
   local war=$1
   local dir_list=${*:2}
-  log "Merging all $(basename "${war}")s ..."
+  debug "Merging all ${war##*/}s ..."
 
   if [ ! -e "${war}" ]; then
     print_and_log "${war} doesn't exist 💀
@@ -331,23 +369,66 @@ merge_all_dirs_to_war() {
     remove_pid_and_exit_in_error
   fi
 
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+  run unzip -q "${war}" -d "${tmp_dir}"
+
   local dir=
   for dir in ${dir_list}; do
     if [ ! -d "${dir}/webapp" ]; then
       continue
     fi
-    (
-      cd "${dir}/webapp" || exit 1
-      zip -q -r -u "${war}" . || {
-        # see 'man zip' for more details
-        if [ $? -eq 12 ]; then
-          log "${war} already contained the contents of ${dir}/webapp"
-        else
-          remove_pid_and_exit_in_error
-        fi
-      }
-    )
+
+    ## Look through all files, JARs and others, and see if they should
+    ## overwrite what's in the ${war} variable.
+    for f in $(find "${dir}" -type f); do
+      # Using builtin BASH string manipulation to save subshell
+      # calls. Need two steps to get a subset of the dir path.
+      local dir_inside_webapp=${f##*webapp/}
+      dir_inside_webapp=${dir_inside_webapp%/*}
+
+      local file_name="${f##*/}"
+      local file_suffix="${file_name##*.}"
+      local dir_inside_war="${tmp_dir}/${dir_inside_webapp}"
+
+      ## the the exploded WAR doesn't contain the file at all, create
+      ## the directory and copy the file.
+      if [ ! -d "${dir_inside_war}" ]; then
+        run mkdir -p "${dir_inside_war}"
+        run cp "${f}" "${dir_inside_war}"
+      else
+        # ok, so the WAR contains the directory of the current file
+        # being checked. Let's see if the WAR has (a different version
+        # of) that file.
+        local package_file_base=
+        package_file_base=$(get_file_base "${f}" "${file_suffix}")
+
+        local file_in_war=
+        for file_in_war in $(find "${dir_inside_war}" -type f); do
+          local file_in_war_name="${file_in_war##*/}"
+          local file_in_war_suffix="${file_in_war_name##*.}"
+
+          local file_in_war_base=
+          file_in_war_base=$(get_file_base "${file_in_war}" "${file_in_war_suffix}")
+
+          if [[ "${package_file_base}" == "${file_in_war_base}" &&
+                  "${file_suffix}" == "${file_in_war_suffix}" ]]; then
+            debug "Removing ${file_in_war} from ${war##*/} since" \
+                  "a different version exists in ${f}."
+            run rm "${file_in_war}"
+          fi
+        done
+
+        # Finally, copy the JAR from the package to the appropriate
+        # place in the WAR tmp dir.
+        debug "Adding ${f} to ${war##*/}"
+        run cp "${f}" "${dir_inside_war}"
+      fi
+    done
   done
+
+  run jar cf "${war}" -C "${tmp_dir}" .
+  run rm -r "${tmp_dir}"
 }
 
 ## Updates studio.war with available studio plugins
@@ -368,25 +449,39 @@ merge_all_plugins_with_studio_war() {
   for dir in ${dir_list}; do
     log "Adding studio plugin in ${dir} ..."
     local plugin_name=
-    plugin_name=$(basename $(dirname "${dir}"))
+    plugin_name=$(basename "${dir%/*}")
+    # our packages are called escenic-<plugin-name>, removing the prefix
+    plugin_name=${plugin_name//escenic[-]}
 
     local tmp_dir=
     tmp_dir=$(mktemp -d)
-    local plugin_dir_in_war="${tmp_dir}/studio/plugin/${plugin_name}"
+    run unzip -q "${war}" -d "${tmp_dir}"
+    local plugin_dir_in_war="${tmp_dir}/studio/plugin/${plugin_name}/lib"
     run mkdir -p "${plugin_dir_in_war}"
-    run cp -r "${dir}"/* "${plugin_dir_in_war}"
 
+    # Check if any of the files in dir exist with a different
+    # version in the target dir.
+    local file=
+    for file in $(find "${dir}" -type f); do
+      local file_suffix=${file##*.}
+      local file_base=
+      file_base=$(get_file_base "${file}" "${file_suffix}")
+
+      find "${plugin_dir_in_war}" \
+           -maxdepth 1 \
+           -type f \
+           -name "${file_base}*${file_suffix}" \
+           -delete
+      run cp "${file}" "${plugin_dir_in_war}/."
+    done
+
+    # to be sure it's prestine, we delete the old war
+    run rm "${war}"
     (
       cd "${tmp_dir}" || exit 1
-      zip -q -r -u "${war}" . || {
-        # see 'man zip' for more details
-        if [ $? -eq 12 ]; then
-          log "${war} already contained the contents of ${dir}"
-        else
-          remove_pid_and_exit_in_error
-        fi
-      }
+      run zip --recurse-paths --quiet "${war}" .
     )
+
     rm -r "${tmp_dir}"
   done
 }
@@ -395,6 +490,11 @@ merge_all_plugins_with_studio_war() {
 merge_all_webservice_extension_webapps() {
   local tmp_dir=$1
   local war=${tmp_dir}/webservice-extensions.war
+  if [ ! -e "${war}" ]; then
+    ## The EAR doesn't contain the war, copy it from the installed
+    ## package.
+    run cp "$(get_installed_package_webservice_extensions_war)" "${war}"
+  fi
   merge_all_dirs_to_war \
     "${war}" \
     "$(get_installed_packages_webservice_extensions_list)"
@@ -404,15 +504,90 @@ merge_all_webservice_extension_webapps() {
 merge_all_webservice_webapps() {
   local tmp_dir=$1
   local war=${tmp_dir}/webservice.war
+  if [ ! -e "${war}" ]; then
+    ## The EAR doesn't contain the war, copy it from the installed
+    ## package.
+    run cp "$(get_installed_package_webservice_war)" "${war}"
+  fi
   merge_all_dirs_to_war \
     "${war}" \
     "$(get_installed_packages_webservice_list)"
+}
+
+## $1 :: top dog WAR Takes precendence when there are libraries in
+##       both WARs. e.g. ECE's webservice.war
+##
+## $2 :: under dog WAR. e.g. the EAR's webservice.war. The file will
+##       be replaced with a ready patched WAR based on the top dog
+##       WAR, with additions in the EAR's webservice.war
+merge_wars_let_first_one_win() {
+  local topdog_war=$1
+  local underdog_war=$2
+
+  log "Replacing ${underdog_war##*/} in the EAR with ${topdog_war}" \
+      "just adding unique files from the version of the WAR inside" \
+      "the EAR."
+  local topdog_tmp_dir=
+  topdog_tmp_dir=$(mktemp -d)
+  local underdog_tmp_dir=
+  underdog_tmp_dir=$(mktemp -d)
+
+  run unzip -q "${topdog_war}" -d "${topdog_tmp_dir}"
+  run unzip -q "${underdog_war}" -d "${underdog_tmp_dir}"
+
+  local topdog_file=
+  local underdog_file=
+  local topdog_file_base=
+  local underdog_file_base=
+
+  # Remove any underdog file that topdog has a (different) version
+  # of. What's left in the underdog WAR will be added to the
+  # uppderog WAR, see below.
+  find "${topdog_tmp_dir}" -type f | while read topdog_file; do
+    local topdog_basename=${topdog_file##*/}
+    local topdog_file_suffix=${topdog_file##*.}
+    local topdog_dirname=${topdog_file%/*}
+    topdog_dirname=${topdog_dirname//${topdog_tmp_dir}}
+    topdog_file_base=$(get_file_base "${topdog_basename}" "${topdog_file_suffix}")
+
+    find "${underdog_tmp_dir}/${topdog_dirname}" \
+         -maxdepth 1 \
+         -name "${topdog_file_base}*${topdog_file_suffix}" \
+         -delete
+  done
+
+  # Use the topdog WAR as base and add any file from underdog WAR that
+  # the topdog doesn't have. The common libraries (but different
+  # version) has been removed in the foor loop above.
+  local tmp_result_war="${underdog_war}".tmp
+  run cp "${topdog_war}" "${tmp_result_war}"
+  (
+    cd "${underdog_tmp_dir}" || exit 1
+    zip -q -r -u "${tmp_result_war}" . || {
+      # see 'man zip' for more details
+      if [ $? -eq 12 ]; then
+        log "${tmp_result_war} already contained the contents of ${underdog_tmp_dir}"
+      else
+        remove_pid_and_exit_in_error
+      fi
+    }
+  )
+
+  run cp "${tmp_result_war}" "${underdog_war}"
+  run rm "${tmp_result_war}"
+  run rm -r "${underdog_tmp_dir}"
+  run rm -r "${topdog_tmp_dir}"
 }
 
 ## $1 :: tmp dir with EAR contents
 merge_all_studio_plugins() {
   local tmp_dir=$1
   local war=${tmp_dir}/studio.war
+  if [ ! -e "${war}" ]; then
+    ## The EAR doesn't contain the war, copy it from the installed
+    ## package.
+    cp "$(get_installed_package_studio_war)" "${war}"
+  fi
   merge_all_plugins_with_studio_war \
     "${war}" \
     "$(get_installed_packages_studio_list)"
@@ -421,12 +596,68 @@ merge_all_studio_plugins() {
 exit_if_no_os_packages_are_installed() {
   local packages_installed=
   packages_installed=$(
-    find "${USR_SHARE_DIR}" -maxdepth 1 -name "escenic-*"  -type d | wc -l)
+    find -L "${USR_SHARE_DIR}" -maxdepth 1 -name "escenic-*"  -type d | wc -l)
 
   if [ "${packages_installed}" -eq 0 ]; then
     print_and_log "No escenic packages installed on ${HOSTNAME} ☹"
     remove_pid_and_exit_in_error
   fi
+}
+
+## Returns 0 if the passed WAR should be merged with that of the
+## package installed version.
+##
+## $1 :: The war, with full path or just file name. Only the basename
+##       will of the war will be compared.
+should_merge_package_war() {
+  local war=$1
+
+  if [ ! -e "${war}" ]; then
+    return 1
+  fi
+
+  declare -a should_be_merged_list=(
+    "webservice.war"
+    "webservice-extensions.war"
+    "studio.war"
+  )
+
+  local el=
+  for el in "${should_be_merged_list[@]}"; do
+    if [[ "${war##*/}" == "${el}"  ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+merge_or_overwrite_webapps_provided_by_packages() {
+  local tmp_dir=$1
+
+  local package_war_list=
+  package_war_list=$(get_installed_packages_war_list)
+
+  local package_war=
+  for package_war in ${package_war_list}; do
+    local war_name=${package_war##*/}
+    local ear_war="${tmp_dir}/${war_name}"
+
+    if should_merge_package_war "${package_war}"; then
+      merge_wars_let_first_one_win "${package_war}" "${ear_war}"
+    else
+      log "Overwriting WAR in EAR with ${package_war} ..."
+      run cp "${package_war}" "${tmp_dir}"
+    fi
+  done
+}
+
+## $1 :: string to be printed (what was being profile)
+## $2 :: start time, seconds since epoch, as in $(date +%s)
+log_profile() {
+  local what=$1
+  local start_time=$2
+  log "Profiling: ${what} took $(($(date +%s) - start_time)) seconds"
 }
 
 ## $1 :: EAR file or URI
@@ -444,16 +675,40 @@ repackage() {
 
   print "Repackaging ${ear} with OS package installed JARs and WARs ..."
   start_time=$(date +%s)
+
+  local method_start=
+
+  method_start=$(date +%s)
   extract_archive "${ear}" "${tmp_dir}"
+  log_profile "extract_archive ${ear}" "${method_start}"
 
+  method_start=$(date +%s)
   remove_libs_included_in_installed_packages "${tmp_dir}"
-  copy_libs_included_in_installed_packages "${tmp_dir}"
+  log_profile "remove_libs_included_in_installed_packages" "${method_start}"
 
-  copy_webapps_included_in_installed_packages_if_not_exists "${tmp_dir}"
-  overwrite_webapp_libs "${tmp_dir}"
+  method_start=$(date +%s)
+  copy_libs_included_in_installed_packages "${tmp_dir}"
+  log_profile "copy_libs_included_in_installed_packages" "${method_start}"
+
+  method_start=$(date +%s)
   merge_all_webservice_extension_webapps "${tmp_dir}"
+  log_profile "merge_all_webservice_extension_webapps" "${method_start}"
+
+  method_start=$(date +%s)
   merge_all_webservice_webapps "${tmp_dir}"
+  log_profile "merge_all_webservice_webapps" "${method_start}"
+
+  method_start=$(date +%s)
   merge_all_studio_plugins "${tmp_dir}"
+  log_profile "merge_all_studio_plugins" "${method_start}"
+
+  method_start=$(date +%s)
+  merge_or_overwrite_webapps_provided_by_packages "${tmp_dir}"
+  log_profile "merge_or_overwrite_webapps_provided_by_packages" "${method_start}"
+
+  method_start=$(date +%s)
+  overwrite_webapp_libs "${tmp_dir}"
+  log_profile "overwrite_webapp_libs" "${method_start}"
 
   # The ${file} variable is used by deploy.sh::deploy()
   export file=$(


### PR DESCRIPTION
- when the EAR contains webservice.war and webservice-extensions.war,
  take the package installed WAR as a basis and just add the files
  unique to the version of the WAR inside the EAR file.

- added unit tests to prove that this works.

- fixed get_file_base() to also normalize timestamped snapshot JARs,
  like engine-jersey-develop-20170126.051354-372.jar,
  which is the Maven timestamp version the
  engine-jersey-develop-SNAPSHOT.jar

- added unit test for get_file_base fix

- added support for /usr/share/escenica being a symlink