### PR TITLE
Added resolver war in standard webapp list for dpres publication to work

### DIFF
--- a/usr/share/escenic/ece-scripts/common-ece.sh
+++ b/usr/share/escenic/ece-scripts/common-ece.sh
@@ -94,6 +94,7 @@ webapps_in_standard_webapps_list="
   live-center
   live-center-presentation-webservice
   revision-history
+  resolver
 "
 
 ### is_webapp_a_publication


### PR DESCRIPTION
This is to allow resolver.war to be deployed as standard webapp in tomcat.