### PR TITLE
ece -i search1 -t search deploy now works with EARs without engine-config JAR

### DIFF
--- a/usr/share/escenic/ece-scripts/ece.d/deploy.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/deploy.sh
@@ -281,5 +281,5 @@ function remove_unwanted_libraries() {
   fi
 
   log "Removing $1/engine-config-*.jar since this is a search instance"
-  run rm $1/engine-config-*.jar
+  run find "${1}/." -maxdepth 1 -name "engine-config-*.jar" -delete
 }


### PR DESCRIPTION
Search instances should not have the engine-config JAR as this will
bootstrap the Nursery framework, which the search doesn't need. This will
just generate loads of errors in the logs.

deploy would therefore remove this JAR file. However, if the EAR doesn't
contain this config jar, the deployment should still work. This fix
fulfils this scenario  having an EAR file tailored for the search
instance.