### PR TITLE
Fix nursery component for memcache with correct class path and directroy hierarchy.  

### DIFF
--- a/usr/share/escenic/ece-scripts/ece-install.d/memory-cache.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/memory-cache.sh
@@ -17,10 +17,10 @@ function install_memory_cache()
 }
 
 function memcached_set_up_common_nursery() {
-  local dir=$common_nursery_dir/com/danga
+  local dir=$common_nursery_dir/com/whalin/
   make_dir $dir
   cat > $dir/SockIOPool.properties <<EOF
-\$class=com.danga.MemCached.SockIOPool
+\$class=com.whalin.MemCached.SockIOPool
 # fill in memcached servers here.
 servers=${fai_memcached_node_list-localhost:11211}
 
@@ -41,6 +41,6 @@ EOF
   cat >> $common_nursery_dir/Initial.properties <<EOF
 
 # using memcached, added by $(basename $0) @ $(date --iso)
-service.0.0-memcached-socket-pool=/com/danga/SockIOPool
+service.0.0-memcached-socket-pool=/com/whalin/SockIOPool
 EOF
 }

--- a/usr/share/escenic/ece-scripts/ece-install.d/memory-cache.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/memory-cache.sh
@@ -17,7 +17,7 @@ function install_memory_cache()
 }
 
 function memcached_set_up_common_nursery() {
-  local dir=$common_nursery_dir/com/whalin/
+  local dir=$common_nursery_dir/com/whalin
   make_dir $dir
   cat > $dir/SockIOPool.properties <<EOF
 \$class=com.whalin.MemCached.SockIOPool


### PR DESCRIPTION
We are using old memcached class path which is com.danga.memcached.SockIOPool till. It need to update to support with Memcached jar that we ship with engine 57 and higher. The class path is now changed to com.whalin.MemCached.SockIOPool which now matches what we ship with engine.