### PR TITLE
Long needed update to the documentation + generated ref doc

### DIFF
--- a/usr/local/src/unit-tests/ece-install-conf-file-reader-extract-doc.sh
+++ b/usr/local/src/unit-tests/ece-install-conf-file-reader-extract-doc.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 shopt -s nullglob
 
-print_doc_header() {
+print_doc_header_md() {
   cat << 'EOF'
 # Configuration Reference for ece-install
 
@@ -21,15 +21,26 @@ Both versions are listed below, grouped by topic.
 EOF
 }
 
-print_doc_footer() {
+print_doc_header_org() {
+  cat <<EOF
+Overview of =ece-install='s configuration options. Generated from the
+configuration file parser's unit tests @ $(LC_ALL=C date).
+EOF
+}
+
+print_doc_footer_md() {
   cat <<EOF
 ---
 Reference guide generated: $(LC_ALL=C date)
 EOF
 }
 
-main() {
-  print_doc_header
+print_doc_footer_org() {
+  :
+}
+
+create_doc_md() {
+  print_doc_header_md
 
   cat ece-install-conf-file-reader-test.sh |
     sed -n '/test_can_parse_yaml_conf_.*() {/,/parse_yaml_conf_file_or_source_if_sh_conf/{
@@ -45,9 +56,30 @@ main() {
   p
 }'
 
-  print_doc_footer
+  print_doc_footer_md
+}
+
+create_doc_org() {
+  print_doc_header_org
+
+  cat ece-install-conf-file-reader-test.sh |
+    sed -n '/test_can_parse_yaml_conf_.*() {/,/parse_yaml_conf_file_or_source_if_sh_conf/{
+  /[ ]*local /d
+  /yaml_file=$(mktemp)/d
+  /cat > "${yaml_file}" <<EOF/d
+
+  s#test_can_parse_yaml_conf_\(.*\)() {#\n*** \1#
+  s#---#\#+begin_src yaml#
+  s#EOF#\#+end_src\n=ece-install.conf= equivalent:\n\#+begin_src: text#
+  s#  unset \(.*\)#\1=#
+  s#[ ]*parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"#\#+end_src#
+  p
+}'
+
+  print_doc_footer_org
 }
 
 
 
-main "$@"
+# create_doc_md "$@"
+create_doc_org "$@"

--- a/usr/local/src/unit-tests/ece-install-conf-file-reader-test.sh
+++ b/usr/local/src/unit-tests/ece-install-conf-file-reader-test.sh
@@ -192,6 +192,64 @@ EOF
   rm -rf "${yaml_file}"
 }
 
+test_can_parse_yaml_conf_search() {
+  local search_port=8000
+  local search_shutdown=5000
+  local search_redirect=4333
+  local search_name=search1
+  local search_host=searchhost
+  local search_legacy=1
+  local search_for_editor=1
+  local search_legacy=1
+  local search_ear=http://builder/engine.ear
+  local search_indexer_ws_uri=http://engine/indexer-webservice/index/
+
+  local yaml_file=
+  yaml_file=$(mktemp)
+  cat > "${yaml_file}" <<EOF
+---
+profiles:
+  search:
+    install: yes
+    legacy: yes
+    ear: ${search_ear}
+    for_editor: true
+    indexer_ws_uri: ${search_indexer_ws_uri}
+    port: ${search_port}
+    host: ${search_host}
+    name: ${search_name}
+    redirect: ${search_redirect}
+    shutdown: ${search_shutdown}
+EOF
+
+  unset fai_search_install
+  unset fai_search_host
+  unset fai_search_port
+  unset fai_search_shutdown
+  unset fai_search_redirect
+  unset fai_search_name
+  unset fai_search_legacy
+  unset fai_search_for_editor
+  unset fai_search_ear
+  unset fai_search_indexer_ws_uri
+
+  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
+  assertNotNull "Should set fai_search_install" "${fai_search_install}"
+  assertEquals "Should set fai_search_install" 1 "${fai_search_install}"
+
+  assertEquals "Should set fai_search_host" "${search_host}" "${fai_search_host}"
+  assertEquals "Should set fai_search_port" "${search_port}" "${fai_search_port}"
+  assertEquals "Should set fai_search_shutdown" "${search_shutdown}" "${fai_search_shutdown}"
+  assertEquals "Should set fai_search_redirect" "${search_redirect}" "${fai_search_redirect}"
+  assertEquals "Should set fai_search_name" "${search_name}" "${fai_search_name}"
+  assertEquals "Should set fai_search_legacy" "${search_legacy}" "${fai_search_legacy}"
+  assertEquals "Should set fai_search_for_editor" "${search_for_editor}" "${fai_search_for_editor}"
+  assertEquals "Should set fai_search_ear" "${search_ear}" "${fai_search_ear}"
+  assertEquals "Should set fai_search_indexer_ws_uri" "${search_indexer_ws_uri}" "${fai_search_indexer_ws_uri}"
+
+  rm -rf "${yaml_file}"
+}
+
 test_can_parse_yaml_conf_db() {
   local yaml_file=
   yaml_file=$(mktemp)
@@ -301,24 +359,6 @@ EOF
   assertEquals "fai_cache_port" "${port}" "${fai_cache_port}"
 
   rm -rf "${yaml_file}"
-}
-
-test_can_parse_yaml_conf_monitoring() {
-  local yaml_file=
-  yaml_file=$(mktemp)
-  local monitoring_install=1
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  monitoring:
-    install: yes
-EOF
-
-  unset fai_monitoring_install
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
-  assertEquals "Wrong fai_monitoring_install" \
-               "${monitoring_install}" \
-               "${fai_monitoring_install}"
 }
 
 test_can_parse_yaml_conf_assembly_tool() {
@@ -719,7 +759,81 @@ EOF
   rm -rf "${yaml_file}"
 }
 
-test_can_parse_yaml_conf_use_escenic_packages() {
+test_can_parse_yaml_conf_analysis() {
+  local yaml_file=
+  yaml_file=$(mktemp)
+
+  local analysis_port=9000
+  local analysis_name=stats1
+  local analysis_shutdown=5553
+  local analysis_redirect=4553
+  local analysis_host=stats1
+
+  cat > "${yaml_file}" <<EOF
+---
+profiles:
+  analysis:
+    install: yes
+    name: ${analysis_name}
+    port: ${analysis_port}
+    host: ${analysis_host}
+    shutdown: ${analysis_shutdown}
+    redirect: ${analysis_redirect}
+EOF
+
+  unset fai_analysis_install
+  unset fai_analysis_name
+  unset fai_analysis_port
+  unset fai_analysis_host
+  unset fai_analysis_shutdown
+  unset fai_analysis_redirect
+  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
+
+  assertNotNull "Should set fai_analysis_install" "${fai_analysis_install}"
+  assertEquals "Should set fai_analysis_install" 1 "${fai_analysis_install}"
+  assertEquals "Should set fai_analysis_name" "${analysis_name}" "${fai_analysis_name}"
+  assertEquals "Should set fai_analysis_port" "${analysis_port}" "${fai_analysis_port}"
+  assertEquals "Should set fai_analysis_host" "${analysis_host}" "${fai_analysis_host}"
+  assertEquals "Should set fai_analysis_shutdown" "${analysis_shutdown}" "${fai_analysis_shutdown}"
+  assertEquals "Should set fai_analysis_redirect" "${analysis_redirect}" "${fai_analysis_redirect}"
+
+  rm -rf "${yaml_file}"
+}
+
+test_can_parse_yaml_conf_analysis_db() {
+  local yaml_file=
+  yaml_file=$(mktemp)
+
+  local analysis_db_user=foouser
+  local analysis_db_password=foopass
+  local analysis_db_schema=fooanalysis_db
+
+  cat > "${yaml_file}" <<EOF
+---
+profiles:
+  analysis_db:
+    install: yes
+    user: ${analysis_db_user}
+    password: ${analysis_db_password}
+    schema: ${analysis_db_schema}
+EOF
+
+  unset fai_analysis_db_install
+  unset fai_analysis_db_user
+  unset fai_analysis_db_password
+  unset fai_analysis_db_schema
+  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
+
+  assertNotNull "Should set fai_analysis_install" "${fai_analysis_install}"
+  assertEquals "Should set fai_analysis_install" 1 "${fai_analysis_install}"
+  assertEquals "Should set fai_analysis_db_user" "${analysis_db_user}" "${fai_analysis_db_user}"
+  assertEquals "Should set fai_analysis_db_password" "${analysis_db_password}" "${fai_analysis_db_password}"
+  assertEquals "Should set fai_analysis_db_schema" "${analysis_db_schema}" "${fai_analysis_db_schema}"
+
+  rm -rf "${yaml_file}"
+}
+
+_test_can_parse_yaml_conf_use_escenic_packages() {
   local yaml_file=
   yaml_file=$(mktemp)
   local foo_java_home=/usr/lib/jvm/foo-java-sdk
@@ -828,138 +942,6 @@ EOF
   rm -rf "${yaml_file}"
 }
 
-test_can_parse_yaml_conf_analysis() {
-  local yaml_file=
-  yaml_file=$(mktemp)
-
-  local analysis_port=9000
-  local analysis_name=stats1
-  local analysis_shutdown=5553
-  local analysis_redirect=4553
-  local analysis_host=stats1
-
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  analysis:
-    install: yes
-    name: ${analysis_name}
-    port: ${analysis_port}
-    host: ${analysis_host}
-    shutdown: ${analysis_shutdown}
-    redirect: ${analysis_redirect}
-EOF
-
-  unset fai_analysis_install
-  unset fai_analysis_name
-  unset fai_analysis_port
-  unset fai_analysis_host
-  unset fai_analysis_shutdown
-  unset fai_analysis_redirect
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
-
-  assertNotNull "Should set fai_analysis_install" "${fai_analysis_install}"
-  assertEquals "Should set fai_analysis_install" 1 "${fai_analysis_install}"
-  assertEquals "Should set fai_analysis_name" "${analysis_name}" "${fai_analysis_name}"
-  assertEquals "Should set fai_analysis_port" "${analysis_port}" "${fai_analysis_port}"
-  assertEquals "Should set fai_analysis_host" "${analysis_host}" "${fai_analysis_host}"
-  assertEquals "Should set fai_analysis_shutdown" "${analysis_shutdown}" "${fai_analysis_shutdown}"
-  assertEquals "Should set fai_analysis_redirect" "${analysis_redirect}" "${fai_analysis_redirect}"
-
-  rm -rf "${yaml_file}"
-}
-
-test_can_parse_yaml_conf_analysis_db() {
-  local yaml_file=
-  yaml_file=$(mktemp)
-
-  local analysis_db_user=foouser
-  local analysis_db_password=foopass
-  local analysis_db_schema=fooanalysis_db
-
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  analysis_db:
-    install: yes
-    user: ${analysis_db_user}
-    password: ${analysis_db_password}
-    schema: ${analysis_db_schema}
-EOF
-
-  unset fai_analysis_db_install
-  unset fai_analysis_db_user
-  unset fai_analysis_db_password
-  unset fai_analysis_db_schema
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
-
-  assertNotNull "Should set fai_analysis_install" "${fai_analysis_install}"
-  assertEquals "Should set fai_analysis_install" 1 "${fai_analysis_install}"
-  assertEquals "Should set fai_analysis_db_user" "${analysis_db_user}" "${fai_analysis_db_user}"
-  assertEquals "Should set fai_analysis_db_password" "${analysis_db_password}" "${fai_analysis_db_password}"
-  assertEquals "Should set fai_analysis_db_schema" "${analysis_db_schema}" "${fai_analysis_db_schema}"
-
-  rm -rf "${yaml_file}"
-}
-
-test_can_parse_yaml_conf_search() {
-  local search_port=8000
-  local search_shutdown=5000
-  local search_redirect=4333
-  local search_name=search1
-  local search_host=searchhost
-  local search_legacy=1
-  local search_for_editor=1
-  local search_legacy=1
-  local search_ear=http://builder/engine.ear
-  local search_indexer_ws_uri=http://engine/indexer-webservice/index/
-
-  local yaml_file=
-  yaml_file=$(mktemp)
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  search:
-    install: yes
-    legacy: yes
-    ear: ${search_ear}
-    for_editor: true
-    indexer_ws_uri: ${search_indexer_ws_uri}
-    port: ${search_port}
-    host: ${search_host}
-    name: ${search_name}
-    redirect: ${search_redirect}
-    shutdown: ${search_shutdown}
-EOF
-
-  unset fai_search_install
-  unset fai_search_host
-  unset fai_search_port
-  unset fai_search_shutdown
-  unset fai_search_redirect
-  unset fai_search_name
-  unset fai_search_legacy
-  unset fai_search_for_editor
-  unset fai_search_ear
-  unset fai_search_indexer_ws_uri
-
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
-  assertNotNull "Should set fai_search_install" "${fai_search_install}"
-  assertEquals "Should set fai_search_install" 1 "${fai_search_install}"
-
-  assertEquals "Should set fai_search_host" "${search_host}" "${fai_search_host}"
-  assertEquals "Should set fai_search_port" "${search_port}" "${fai_search_port}"
-  assertEquals "Should set fai_search_shutdown" "${search_shutdown}" "${fai_search_shutdown}"
-  assertEquals "Should set fai_search_redirect" "${search_redirect}" "${fai_search_redirect}"
-  assertEquals "Should set fai_search_name" "${search_name}" "${fai_search_name}"
-  assertEquals "Should set fai_search_legacy" "${search_legacy}" "${fai_search_legacy}"
-  assertEquals "Should set fai_search_for_editor" "${search_for_editor}" "${fai_search_for_editor}"
-  assertEquals "Should set fai_search_ear" "${search_ear}" "${fai_search_ear}"
-  assertEquals "Should set fai_search_indexer_ws_uri" "${search_indexer_ws_uri}" "${fai_search_indexer_ws_uri}"
-
-  rm -rf "${yaml_file}"
-}
-
 test_can_parse_yaml_conf_editor_install_multi_profiles() {
   local yaml_file=
   yaml_file=$(mktemp)
@@ -982,47 +964,6 @@ EOF
   assertNotNull "Should set fai_editor_install" "${fai_editor_install}"
   assertEquals "Should set fai_editor_install" 1 "${fai_editor_install}"
   assertEquals "Should set fai_search_install" 1 "${fai_search_install}"
-  assertNull "Should not have set fai_db_install" "${fai_db_install}"
-
-  rm -rf "${yaml_file}"
-}
-
-test_can_parse_yaml_conf_db() {
-  local yaml_file=
-  yaml_file=$(mktemp)
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  db:
-    install: yes
-EOF
-
-  unset fai_db_install
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
-  assertNotNull "Should set fai_db_install" "${fai_db_install}"
-  assertEquals "Should set fai_db_install" 1 "${fai_db_install}"
-
-  # now, try to set it to true
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  db:
-    install: true
-EOF
-  unset fai_db_install
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
-  assertNotNull "Should set fai_db_install" "${fai_db_install}"
-  assertEquals "Should set fai_db_install" 1 "${fai_db_install}"
-
-  # now, try to set it to false
-  cat > "${yaml_file}" <<EOF
----
-profiles:
-  db:
-    install: false
-EOF
-  unset fai_db_install
-  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
   assertNull "Should not have set fai_db_install" "${fai_db_install}"
 
   rm -rf "${yaml_file}"
@@ -1103,6 +1044,24 @@ EOF
   assertEquals "${expected}" "${actual}"
 
   rm -rf "${yaml_file}"
+}
+
+test_can_parse_yaml_conf_monitoring() {
+  local yaml_file=
+  yaml_file=$(mktemp)
+  local monitoring_install=1
+  cat > "${yaml_file}" <<EOF
+---
+profiles:
+  monitoring:
+    install: yes
+EOF
+
+  unset fai_monitoring_install
+  parse_yaml_conf_file_or_source_if_sh_conf "${yaml_file}"
+  assertEquals "Wrong fai_monitoring_install" \
+               "${monitoring_install}" \
+               "${fai_monitoring_install}"
 }
 
 ## @override shunit2

--- a/usr/share/doc/escenic/ece-install-conf-reference.org
+++ b/usr/share/doc/escenic/ece-install-conf-reference.org
@@ -1,0 +1,493 @@
+Overview of =ece-install='s configuration options. Generated from the
+configuration file parser's unit tests @ Tue May  2 09:01:11 CEST 2017.
+
+*** environment
+
+#+begin_src yaml
+environment:
+  type: ${environment_type}
+  java_home: ${foo_java_home}
+  java_version: ${foo_java_version}
+  skip_password_checks: true
+  conf_url: ${conf_url}
+  apt:
+    escenic:
+      pool: ${apt_pool}
+  deb:
+    escenic:
+      use_deb_not_apt: true
+      base_url: ${deb_base_url}
+  rpm:
+    escenic:
+      base_url: ${rpm_base_url}
+
+  maven:
+    repositories:
+      - ${mvn_repo1}
+      - ${mvn_repo2}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+java_home=
+fai_environment=
+fai_server_java_version=
+fai_maven_repositories=
+fai_conf_url=
+fai_package_rpm_base_url=
+fai_package_deb_not_apt=
+
+#+end_src
+
+*** editor
+
+#+begin_src yaml
+profiles:
+  editor:
+    install: yes
+    port: ${editor_port}
+    host: ${editor_host}
+    name: ${editor_name}
+    redirect: ${editor_redirect}
+    shutdown: ${editor_shutdown}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_editor_install=
+fai_editor_port=
+fai_editor_shutdown=
+fai_editor_redirect=
+fai_editor_name=
+
+#+end_src
+
+*** presentation
+
+#+begin_src yaml
+profiles:
+  presentation:
+    install: yes
+    ear: ${presentation_ear}
+    environment: ${presentation_environment}
+    host: ${presentation_host}
+    name: ${presentation_name}
+    port: ${presentation_port}
+    redirect: ${presentation_redirect}
+    shutdown: ${presentation_shutdown}
+    deploy_white_list: ${presentation_deploy_white_list}
+    search_indexer_ws_uri: ${presentation_search_indexer_ws_uri}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_presentation_ear=
+fai_presentation_environment=
+fai_presentation_install=
+fai_presentation_name=
+fai_presentation_port=
+fai_presentation_redirect=
+fai_presentation_shutdown=
+fai_presentation_deploy_white_list=
+fai_presentation_search_indexer_ws_uri=
+
+#+end_src
+
+*** search
+
+#+begin_src yaml
+profiles:
+  search:
+    install: yes
+    legacy: yes
+    ear: ${search_ear}
+    for_editor: true
+    indexer_ws_uri: ${search_indexer_ws_uri}
+    port: ${search_port}
+    host: ${search_host}
+    name: ${search_name}
+    redirect: ${search_redirect}
+    shutdown: ${search_shutdown}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_search_install=
+fai_search_host=
+fai_search_port=
+fai_search_shutdown=
+fai_search_redirect=
+fai_search_name=
+fai_search_legacy=
+fai_search_for_editor=
+fai_search_ear=
+fai_search_indexer_ws_uri=
+
+#+end_src
+
+*** db
+
+#+begin_src yaml
+profiles:
+  db:
+    install: ${db_install}
+    master: true
+    user: ${db_user}
+    ear: ${db_ear}
+    password: ${db_password}
+    schema: ${db_schema}
+    host: ${db_host}
+    port: ${db_port}
+    drop_old_db_first: yes
+    replication: yes
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_db_install=
+fai_db_master=
+fai_db_user=
+fai_db_password=
+fai_db_schema=
+fai_db_host=
+fai_db_port=
+fai_db_ear=
+fai_db_drop_old_db_first=
+fai_db_replication=
+#+end_src
+
+*** cache
+
+#+begin_src yaml
+profiles:
+  cache:
+    install: yes
+    conf_dir: ${conf_dir}
+    port: ${port}
+    backends:
+      - ${be1}
+      - ${be2}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_cache_install=
+fai_cache_backends=
+fai_cache_port=
+fai_cache_conf_dir=
+
+#+end_src
+
+*** assembly_tool
+#+begin_src yaml
+profiles:
+  assembly_tool:
+    install: yes
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_assembly_tool_install=
+#+end_src
+
+*** credentials
+
+#+begin_src yaml
+credentials:
+  - site: maven.escenic.com
+    user: ${escenic_download_user}
+    password: ${escenic_download_password}
+  - site: builder
+    user: ${builder_download_user}
+    password: ${builder_download_password}
+  - site: unstable.yum.escenic.com
+    user: ${unstable_yum_user}
+    password: ${unstable_yum_password}
+  - site: unstable.apt.escenic.com
+    user: ${unstable_apt_user}
+    password: ${unstable_apt_password}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+technet_user=
+technet_password=
+fai_package_rpm_user=
+fai_package_rpm_password=
+fai_package_apt_user=
+fai_package_apt_password=
+fai_builder_http_user=
+fai_builder_http_password=
+fai_conf_builder_http_user=
+fai_conf_builder_http_password=
+
+#+end_src
+
+*** credentials_stable_yum
+
+#+begin_src yaml
+credentials:
+  - site: yum.escenic.com
+    user: ${stable_yum_user}
+    password: ${stable_yum_password}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_package_rpm_user=
+fai_package_rpm_password=
+
+#+end_src
+
+*** credentials_stable_apt
+
+#+begin_src yaml
+credentials:
+  - site: apt.escenic.com
+    user: ${stable_apt_user}
+    password: ${stable_apt_password}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_package_apt_user=
+fai_package_apt_password=
+
+#+end_src
+
+*** create_publication
+
+
+#+begin_src yaml
+profiles:
+   publications:
+     - name: ${publication1_name}
+       create: true
+       update_app_server_conf: true
+       update_ece_conf: true
+       update_nursery_conf: true
+       war: ${publication1_war}
+       war_remove_list:
+         - ${publication1_remove_file1}
+         - ${publication1_remove_file2}
+       webapps:
+         - ${publication_webapp1}
+         - ${publication_webapp2}
+       domain: ${publication1_domain}
+       ear: ${publication_ear}
+       environment: ${publication1_environment}
+       aliases:
+         - ${publication1_alias1}
+         - ${publication1_alias2}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_publication_domain_mapping_list=
+fai_publication_ear=
+fai_publication_update_app_server_conf=
+fai_publication_update_ece_conf=
+fai_publication_update_nursery_conf=
+fai_publication_war_remove_file_list=
+fai_publication_environment=
+fai_publication_webapps=
+fai_publications_webapps # arg, the plural=
+
+#+end_src
+
+*** publication
+
+
+#+begin_src yaml
+profiles:
+   publications:
+     - name: ${publication1_name}
+       war: ${publication1_war}
+       domain: ${publication1_domain}
+       aliases:
+         - ${publication1_alias1}
+         - ${publication1_alias2}
+     - name: ${publication2_name}
+       war: ${publication2_war}
+       domain: ${publication2_domain}
+       aliases:
+          - ${publication2_alias1}
+          - ${publication2_alias2}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_publication_domain_mapping_list=
+#+end_src
+
+*** packages
+
+#+begin_src yaml
+packages:
+  - name: ${package_name}
+    version: ${package_version}
+    arch: ${package_arch}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+fai_package_map=
+fai_package_arch_map=
+  declare -A fai_package_map
+  declare -A fai_package_arch_map
+#+end_src
+
+*** packages_multiple
+
+
+#+begin_src yaml
+packages:
+  - name: ${package_name}
+    version: ${package_version}
+  - name: ${package_name_without_version}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+fai_package_map=
+  declare -A fai_package_map
+#+end_src
+
+*** analysis
+
+
+#+begin_src yaml
+profiles:
+  analysis:
+    install: yes
+    name: ${analysis_name}
+    port: ${analysis_port}
+    host: ${analysis_host}
+    shutdown: ${analysis_shutdown}
+    redirect: ${analysis_redirect}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_analysis_install=
+fai_analysis_name=
+fai_analysis_port=
+fai_analysis_host=
+fai_analysis_shutdown=
+fai_analysis_redirect=
+#+end_src
+
+*** analysis_db
+
+
+#+begin_src yaml
+profiles:
+  analysis_db:
+    install: yes
+    user: ${analysis_db_user}
+    password: ${analysis_db_password}
+    schema: ${analysis_db_schema}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_analysis_db_install=
+fai_analysis_db_user=
+fai_analysis_db_password=
+fai_analysis_db_schema=
+#+end_src
+_
+*** use_escenic_packages
+
+#+begin_src yaml
+packages:
+  foo: 1
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_package_enabled=
+#+end_src
+
+*** restore
+
+#+begin_src yaml
+profiles:
+  restore:
+    pre_wipe_solr: true
+    pre_wipe_all: true
+    pre_wipe_logs: true
+    pre_wipe_cache: true
+    pre_wipe_crash: true
+    from_backup: true
+    data_files: true
+    software_binaries: true
+    db: true
+    configuration: true
+    from_file: ${restore_from_file}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+fai_restore_pre_wipe_solr=
+fai_restore_pre_wipe_all=
+fai_restore_pre_wipe_logs=
+fai_restore_pre_wipe_cache=
+fai_restore_pre_wipe_crash=
+fai_restore_from_backup=
+fai_restore_data_files=
+fai_restore_software_binaries=
+fai_restore_db=
+fai_restore_configuration=
+fai_restore_from_file=
+#+end_src
+
+*** editor_install_multi_profiles
+#+begin_src yaml
+profiles:
+  editor:
+    install: yes
+  search:
+    install: yes
+  db:
+    install: no
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_editor_install=
+fai_search_install=
+fai_db_install=
+
+#+end_src
+
+*** cache
+
+#+begin_src yaml
+profiles:
+  cache:
+    install: yes
+    port: ${cache_port}
+    conf_dir: ${cache_conf_dir}
+    backends:
+      - ${cache_be1}
+      - ${cache_be2}
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_cache_install=
+fai_cache_backends=
+fai_cache_conf_dir=
+fai_cache_port=
+
+#+end_src
+
+*** monitoring
+#+begin_src yaml
+profiles:
+  monitoring:
+    install: yes
+#+end_src
+=ece-install.conf= equivalent:
+#+begin_src: text
+
+fai_monitoring_install=
+#+end_src

--- a/usr/share/doc/escenic/ece-install-guide.org
+++ b/usr/share/doc/escenic/ece-install-guide.org
@@ -13,7 +13,7 @@ ece-install [[[-f|--file conf-file]]] [[[-V|--version]]] [[[-v|--verbose]]]
 * OPTIONS
 ** -f|--file conf-file
 Instructs *ece-install* to read configuration data from the specified
-file.
+file. This can either be a `.conf` or `.yaml` file.
 
 ** -v|--verbose
 Requests verbose output from *ece-install*.
@@ -53,32 +53,17 @@ need to install manually, and it still handles the configuration of
 these components for you.
 
 ** Supported Operating Systems
-*ece-install* works best on Debian 6.0 (Squeeze) or later. It should,
-however, work on any UNIX-like system that provides a BASH command
-shell (version 4.2 or later).
+| Operating system            | Status                       |
+|-----------------------------+------------------------------|
+| Debian 8.7 (jessie)         | Everything is 100% automatic |
+| Ubuntu LTS 16.04            | Everything is 100% automatic |
+| RedHat Enterprise Linux 7.3 | Everything is 100% automatic |
+| CentOS 7.3                  | Everything is 100% automatic |
 
-Here is an overview of the situation on some of the most popular
-platforms:
-
- - Debian-based operating systems :: On Debian 6.0 or later,
-     installation is fully automated. *ece-install* installs and
-     configures all required components. This may also be the case on
-     some Debian-based distributions. On recent Ubuntu distributions,
-     however, you will need to manually install some components. For
-      details, see Tested Operating Systems.
-
- - RedHat-based operating systems :: *ece-install* support for
-      RedHat-based operating systems is constantly improving. However,
-      since the public RedHat software repositories are significantly smaller
-      than the Debian ones, it may often be necessary to manually
-      install some components. For
-      details, see Tested Operating Systems.
-
- - Other GNU/Linux and UNIX systems :: *ece-install* does not currently support
-      automated installation of third-party components on these
-      platforms, so you will need to install them manually. It will,
-      of course, tell you which components you need to install, and
-      configure them for you.
+Other Unix operating systems may work, given that the required
+binaries (=curl=, =varnishd=, =mysqld=++) are already available in
+PATH and that the configuration files exist in familiar
+locations. However this is untested. YMMV.
 
 ** Requirements
 Whichever operating system(s) you will be installing on, you must ensure
@@ -115,14 +100,6 @@ Platforms on which you will need to do this include:
  - Any BSD-based system (including Mac OS X)
  - Solaris
 
-** <<<Tested Operating Systems>>>
-| Operating system     | Status                                     |
-|----------------------+--------------------------------------------|
-| CentOS 6.2           | HA, APR & monitoring are not automatic     |
-| Debian 6.0 (squeeze) | Everything is 100% automatic               |
-| Ubuntu 11.10         | Everything except Tomcat/APR are automatic |
-| Ubuntu LTS 10.04     | Everything except Tomcat/APR are automatic |
-| Ubuntu LTS 12.04     | Everything except Tomcat/APR are automatic |
 
 * Using ece-install
 The various software components required to run an Escenic-powered web
@@ -185,67 +162,34 @@ before running *ece-install*.
 #+END_QUOTE
 
 ** <<<Create a Configuration File>>>
-*ece-install* expects to find a configuration file called
-*ece-install.conf* in the root user's home directory, which is usually
-*/root*. If you wish to call your configuration file something else,
-you need to specify it with the *-f* parameter, e.g. *ece-install -f
-ece-install-db-master.conf=.
+*ece-install* can use configuration files in either =.conf= (old) or
+*=.yaml= (new) format. This manual describes first and foremost the
+*YAML format.
 
-If you forget to provide such a file before running *ece-install*,
-then *ece-install* will complain:
-#+BEGIN_SRC text
-[ece-install] /root/ece-install.conf doesn't exist,
-I cannot live without it :-(
-#+END_SRC
-
-*/root/ece-install.conf*. may contain a large number of configuration
+*ece-install.yaml*. may contain a large number of configuration
 parameters, but the minimum requirement is that it contains:
 
- * A user name and password for downloading software from Escenic
-   Technet.
- * The parameter *fai\_enabled=1*.
- * A parameter of the form *fai\_<profile>\_install=1* where *<profile>*
-   is the name of the *profile* you want to install (see Server
-   Profiles for information about profiles).
+ * A user name and password for downloading software from Escenic.
+ * A profile to install
 
 For example:
-#+BEGIN_SRC conf
-technet_user=<user>
-technet_password=<password>
-fai_<profile>_install=1
-fai_server_java_version=1.7
-#+END_SRC
-
-If the configuration file does not contain these settings then
-*ece-install* will complain. For example:
-#+BEGIN_SRC text
-[ece-install] Be sure to set technet_user and technet_password
-[ece-install] in /root/ece-install.conf
+#+BEGIN_SRC yaml
+credentials:
+  - site: maven.escenic.com
+    user: foo
+    password: bar
+  - site: apt.escenic.com
+    user: foo
+    password: bar
+profiles:
+  editor:
+    install: yes
 #+END_SRC
 
 Depending on what components you are installing on the server, you may
-need to include other configuration parameters in the file. If you are
-installing the Widget Framework, for example, you will need to specify
-additional download credentials (see [[fai_wf_install]]). In most cases,
-however, parameters have default settings that enable *ece-install* to
-complete installation with very few settings.
-
-****** Interactive Mode
-The setting *fai\_enabled=1* tells *ece-install* to run in *fully
-automated install (FAI)* mode. In this mode *ece-install* reads
-parameters from *ece-install.conf*. If it cannot find all the
-parameters it needs in the configuration file, then it fails. This is
-the recommended way to use *ece-install*.
-
-If you omit this parameter then *ece-install* will not read any
-*fai\_???* parameters from *ece-install.conf* and will prompt for them
-interactively instead. You are, however, *strongly advised* not to run
-*ece-install* in interactive mode:
-
- * Interactive mode is much less flexible than FAI mode.
- * Interactive mode is not actively maintained and may therefore be
-   unreliable.
- * Use of interactive mode is therefore not supported.
+need to include other configuration parameters in the file. In most
+cases, however, parameters have default settings that enable
+*ece-install* to complete installation with very few settings.
 
 ** <<<Run ece-install>>>
 To run *ece-install*, enter:
@@ -329,41 +273,49 @@ role in an Escenic installation.
 The profile to be installed by *ece-install* is determined by setting
 one of the following parameters in *ece-install.conf*:
 
-- *fai\_editor\_install=1* :: Installs all the components that need to
+- *profiles: editor* :: Installs all the components that need to
      be installed to create an Escenic *editorial server*.
-- *fai\_presentation\_install=1* :: Installs all the components that
+- *profiles: presentation* :: Installs all the components that
      need to be installed to create an Escenic *presentation server*.
-- *fai\_wf\_install=1* :: Installs the Widget Framework on an editorial
-     or presentation server.
-- *fai\_db\_install=1* :: Installs a Database Server.
-- *fai\_cache\_install=1* :: Installs a Cache Server.
-- *fai\_search\_install=1* :: Installs a Search Server.
-- *fai\_rmi\_install=1* :: Installs an RMI Hub.
-- *fai\_monitoring\_install=1* :: Installs a Monitoring Server.
-- *fai\_publication\_create=1* :: Creates an Escenic publication.
-- *fai\_all\_install=1* :: Installs all of the above on one host
+- *profiles: db* :: Installs a Database Server.
+- *profiles: cache* :: Installs a Cache Server.
+- *profiles: search* :: Installs a Search Server.
+- *profiles: publication* :: Creates an Escenic publication.
+- *profiles: all* :: Installs all of the above on one host
      machine.
-- *fai\_restore\_from\_backup=1* :: Restores a backup created with *ece*.
-- *fai\_analysis\_install=1* :: Installs and configures an Escenic Analysis Engine.
-- *fai\_nfs\_server\_install=1* :: Installs an NFS server.
-- *fai\_nfs\_client\_install=1* :: Installs an NFS client.
-- *fai\_vip\_install=1* :: Installs virtual IP (VIP) providers.
+- *profiles: restorebackup* :: Restores a backup created with *ece*.
+- *profiles: analysis* :: Installs and configures an Escenic Analysis Engine.
+- *profiles: nfs* :: Installs an NFS server.
+- *profiles: nfs* :: Installs an NFS client.
+- *profiles: vip* :: Installs virtual IP (VIP) providers.
 
 There are a number of common components that are included in all or
 most of the profiles. These are described below.
 
-** <<<fai\_editor\_install>>>
-To use this profile add *fai\_editor\_install=1* to your
-*ece-install.conf* file.
+** <<<profiles: editor>>>
+To use this profile add:
+#+begin_src yaml
+profiles:
+  editor:
+    create: true
+#+end_src
+
+to your *ece-install.yaml* file.
 
 This profile contains all the components that need to be installed to
 create an Escenic *editorial server*. An editorial server (sometimes
 also called a publication server) hosts a Content Engine used for editorial
 purposes (primarily Content Studio sessions).
 
-** <<<fai\_presentation\_install>>>
-To use this profile, add *fai\_presentation\_install=1* to your
-*ece-install.conf* file.
+** <<<profiles: presentation>>>
+To use this profile, add:
+#+begin_src yaml
+profiles:
+  presentation:
+    create: true
+#+end_src
+
+to your *ece-install.yaml* file.
 
 This profile contains all the components that need to be installed to
 create an Escenic *presentation server*. A presentation server hosts a
@@ -375,46 +327,26 @@ users. Differences between this and an editorial server include:
    required.
  * Memcached, the distributed memory cache is installed.
 
-** <<<fai\_wf\_install>>>
-To use this profile, add the following settings:
-#+BEGIN_SRC text
-fai_wf_install=1
-wf_user=<user-name>
-wf_password=<password>
-#+END_SRC
+** <<<profiles: db>>>
+To use this profile, add:
 
-to your *ece-install.conf* file.
+#+begin_src yaml
+profiles:
+  db:
+    create: true
+#+end_src
 
-*wf\_user* and *wf\_password* must contain your Widget Framework Maven
-repository credentials (supplied when you purchased the Widget
-Framework). If you do not have these credentials, please contact
-support@escenic.com.
+to your *ece-install.yaml* file.
 
-This profile installs the Escenic Widget Framework. It should be
-installed on a machine where you have already installed either an
-editorial or presentation profile. Exactly which machines you install
-the Widget Framework on depends on your deployment strategy.
+When this profile is used on a supported version of Debian, Ubuntu,
+CentOS or RedHat, *ece-install* installs will install all the
+components needed to create an Escenic database, based on the MariaDB
+fork of MySQL or the Percona distribution of MySQL.
 
-** <<<fai\_db\_install>>>
-To use this profile, add *fai\_db\_install=1* to your
-*ece-install.conf* file.
+The default is to install MariaDB.
 
-When this profile is used on a supported version of Debian or Ubuntu,
-*ece-install* installs all the components needed to create an Escenic
-database, based on the MariaDB fork of MySQL or the Percona
-distribution of MySQL. On any other platform you must install either
-MariaDB, Percona or a standard MySQL distribution yourself before running
-*ece-install*.
-
-The default is to install MariaDB unless this setting is added to to
-*ece-install.conf* before you run *ece-install*.
-
-#+BEGIN_SRC conf
-db_vendor=percona
-#+END_SRC
-
-Otherwise, this profile contains all the Escenic components needed on
-a database server plus the correct database schema for the Content
+Furthermore, this profile contains all the Escenic components needed
+on a database server plus the correct database schema for the Content
 Engine version and plug-in versions you are installing.
 
 If an Escenic database has already been installed on the machine, then
@@ -430,29 +362,31 @@ If an Escenic database has already been installed on the machine, then
 #+END_SRC
 
 If you actually want to re-install the database you can do so by
-adding this setting to *ece-install.conf* before you run *ece-install*:
+adding this setting to *ece-install.yaml* before you run *ece-install*:
 
-#+BEGIN_SRC conf
-fai_db_drop_old_db_first=1
+#+BEGIN_SRC yaml
+profiles:
+  db:
+    install: true
+    drop_old_db_first: true
 #+END_SRC
 
 Given that *mysqld* is installed, this profile will download all the
-Escenic components and install the ECE database schema based from the
-SQL files contained inside the distribution bundles specified with in
-the *technet\_download\_list* and *wf\_dowload\_list* variables. The
-defaults are inside the *ece-install* command itself, but you can
-overrides these in your *ece-install.conf* if you wish different minor
-versions of the ECE and plugins.
+Escenic components that you have defined in the configuration file and
+install the ECE database schema based from the SQL files contained
+inside the individual packages.
 
 *** Master & slave setup
 You can easily use *ece-install* to set up master and slave databases
 on different hosts.
 
-First create the master database using these *ece-install.conf* settings:
-#+BEGIN_SRC conf
-fai_db_install=1
-fai_db_master=1
-fai_db_replication=1
+First create the master database using these *ece-install.yaml* settings:
+#+BEGIN_SRC yaml
+profiles:
+  db:
+    install: true
+    master: true
+    replication: true
 #+END_SRC
 
 When you run *ece-install* with these settings, the output log
@@ -467,14 +401,16 @@ database:
 #+END_SRC
 
 On the slave database host you can then use these values in your
-*ece-install.conf* file as follows:
-#+BEGIN_SRC conf
-fai_db_install=1
-fai_db_replication=1
-fai_db_master=0
-fai_db_master_host=my-db-master
-fai_db_master_log_file=mysql-bin.000013
-fai_db_master_log_position=106
+*ece-install.yaml* file as follows:
+#+BEGIN_SRC yaml
+profiles:
+  db:
+    install: true
+    master: false
+    replication: true
+    master_host: "my-db-master"
+    master_log_file: "mysql-bin.000013"
+    master_log_position: "106"
 #+END_SRC
 
 *ece-install* uses internal defaults to create a replication user and
@@ -482,14 +418,21 @@ credentials. You can override these defaults by setting additional
 parameters in *ece-install.conf*. For details, see [[Overview of All FAI
 Parameters]].
 
-** <<<fai\_cache\_install>>>
-To use this profile, add *fai\_cache\_install=1* to your
-*ece-install.conf* file.
+** <<<profiles: cache>>>
+To use this profile, add:
+
+#+begin_src yaml
+profiles:
+  cache:
+    install: true
+#+end_src
+
+
+to your *ece-install.yaml* file.
 
 When this profile is used on a supported version of Debian or Ubuntu,
-*ece-install* installs the latest Varnish 3.x caching server from the
-Varnish APT repository. On any other platform you must install Varnish 3.x
-yourself before running *ece-install*.
+*ece-install* installs the latest Varnish caching server from the
+official distro repositories.
 
 Once Varnish is installed, *ece-install* configures it to suit the
 typical requirements of an Escenic site:
@@ -519,71 +462,68 @@ TBD:
   configuration.
 #+END_COMMENT
 
-** <<<fai\_search\_install>>>
-To use this profile, add *fai\_search\_install=1* to your
-*ece-install.conf* file.
+** <<<profiles: search>>>
+To use this profile, add
 
-This profile installs search components (Apache Solr plus the Escenic
-*indexer* web app.
+#+begin_src yaml
+profiles:
+  search:
+    install: true
+#+end_src
 
-** <<<fai\_rmi\_install>>>
-To use this profile, add *fai\_rmi\_install=1* to your
-*ece-install.conf* file.
 
-This profile installs an RMI hub. This is only necessary on systems
-using ECE < 5.3
+to your *ece-install.yaml* file.
 
-** <<<fai\_monitoring\_install>>>
-To use this profile, add *fai\_monitoring\_install=1* to your
-*ece-install.conf* file.
+This profile installs a standalone Solr instance and an app server
+with the Escenic *indexer* web app.
 
-This profile installs a Munin gatherer, a Icinga (an enhanced Nagios)
-server plus a web server for providing access to Icinga and the
-reports Munin generates.
+** <<<profiles: publications>>>
+To use this profile, add
 
-** <<<fai\_publication\_create>>>
-To use this profile, add *fai\_publication\_create=1* to your
-*ece-install.conf* file.
+#+begin_src yaml
+profiles:
+  publications:
+    - name: mypub
+      create: true
+#+end_src
+
+
+to your *ece-install.yaml* file.
 
 This profile creates a publication for you. It should be used on a
 machine where you have already installed either an editorial or
 presentation profile.
 
-If the Widget Framework is installed on the machine, then the
-create publication is based on the Widget Framework. Otherwise the
-publication is based on the clean demo WAR supplied with the Content
-Engine.
-
 *ece-install* will create publications of all the publication WAR
 files in your EAR file if you also
-define *fai\_publication\_domain\_mapping\_list*
-and *fai\_publication\_ear*.
-#+BEGIN_SRC text
-fai_publication_create=1
-fai_publication_ear=/tmp/stoppok-rev6195-2012-12-04_1134.ear
-fai_publication_domain_mapping_list="
-  stoppok,st.war#stoppok.example.com#newindian.example.com
-  helden#dinamani.example.com#helden.example.com
-"
+define domain (and optionally, aliases):
+#+BEGIN_SRC yaml
+profiles:
+  publications:
+    - name: stoppok
+      domain: stoppok.example.com
+      aliases:
+        - s.exampel.com
+        - o.exampel.com
+      ear: /tmp/stoppok-rev6195-2012-12-04_1134.ear
+    - name: helden
+      domain: helden.example.com
+      ear: /tmp/stoppok-rev6195-2012-12-04_1134.ear
 #+END_SRC
 
 See [[Overview of All Configuration Parameters]] for further details on the format
 of the domain mapping list.
 
-** <<<fai\_all\_install>>>
-To use this profile, add *fai\_all\_install=1* to your
-*ece-install.conf* file.
+** <<<profiles: restore>>>
+To use this profile, add:
 
-This profile is primarily intended for use by developers and system
-administrators as a test environment. It is *not* considered suitable
-for production purposes. A complete stack including caching
-server, application server, Escenic Content Engine, assembly host,
-database and Widget Framework is installed. In addition, a publication
-is created.
+#+begin_src yaml
+profiles:
+  restore:
+    from_file: /var/backups/backup.tar.gz
+#+end_src
 
-** <<<fai\_restore\_from\_backup>>>
-To use this profile, add *fai\_restore\_from\_backup=1* to your
-*ece-install.conf* file.
+to your *ece-install.yaml* file.
 
 Unlike all the other profiles, this profile does not install anything
 or create anything new. Instead, it restores a backup you have
@@ -614,48 +554,49 @@ parameters in *ece-install.conf* in order to specify the location of
 the backup file you want to restore and the specific items you want to
 restore from the file.
 
-The parameters you can use together with *fai\_restore\_from\_backup*
+The parameters you can use together with *profiles: restore*
 to specify what you want to restore are:
 
-- *fai\_restore\_all* :: Restore all backup items. Requires a full
-     backup tarball. Default is 1.
+#+begin_src yaml
+profiles:
+  restore:
+    # The *.tar* file produced by *ece -i <instance> backup*. Default is "".
+    from_file:
+    from_backup: true
 
-- *fai\_restore\_db* :: Install the database server and restore its
-     contents. Default is 0
+    # Restore the Solr and Content Engine data files. Default is false.
+    data_files: true
 
-- *fai\_restore\_data\_files* :: Restore the Solr and Content Engine
-     data files. Default is 0
+    # Restore the Escenic and Apache Tomcat software. Default is false.
+    software_binaries: true
 
-- *fai\_restore\_configuration* :: Restore the Solr and content Engine
-     configuration files. Default is 0.
-- *fai\_restore\_software\_binaries* :: Restore the Escenic and Apache
-     Tomcat software. Default is 0.
+    # Install the database server and restore its. Default false
+    db: true
 
-- *fai\_restore\_from\_file* :: The *.tar* file produced by *ece -i
-     <instance> backup*. Default is "".
+    # Restore the Solr and content Engine configuration files. Default is  false
+    configuration: true
+#+end_src
 
-So to restore everything in a specified backup file, you would need
-something like this in your *ece-install.conf* file:
-#+BEGIN_SRC conf
-fai_restore_from_backup=1
-fai_restore_all=1
-fai_restore_from_file=/var/backups/escenic/backup-2011-10-10.tar
-#+END_SRC
 
 *ece-install* can also remove unwanted files from an existing
 installation prior to restoring from a backup. You can specify the
 files you would like to remove using the following parameters:
 
-- *fai\_restore\_pre\_wipe\_all* :: Remove all data/state & log
-     files. Default is 0.
-- *fai\_restore\_pre\_wipe\_cache* :: Remove the cache files. Default
-     is 0.
-- *fai\_restore\_pre\_wipe\_crash* :: Remove the crash files. Default
-     is 0.
-- *fai\_restore\_pre\_wipe\_logs*  :: Remove all log files. Default
-     is 0.
-- *fai\_restore\_pre\_wipe\_solr*  :: Remove the solr data/state
-     files. Default is 0.
+#+begin_src yaml
+profiles:
+  restore:
+    # Remove the solr data/state files. Default is false.
+    pre_wipe_solr: true
+    # Remove all log files. Default is false.
+    pre_wipe_logs: true
+    # Remove the cache files. Default is false.
+    pre_wipe_cache: true
+    # Remove the crash files. Default is false.
+    pre_wipe_crash: true
+
+    # Remove all of the above
+    pre_wipe_all: true
+#+end_src
 
 *** Data security
 You must be careful when restoring backups that you don't
@@ -680,9 +621,16 @@ restore will fail as follows:
   details.
 #+END_SRC
 
-** <<<fai\_analysis\_install>>>
-To use this profile, add *fai\_analysis\_install=1* to your
-*ece-install.conf* file.
+** <<<profiles: analysis>>>
+To use this profile, add:
+
+#+begin_src yaml
+profiles:
+  analysis:
+    create: true
+#+end_src
+
+to your *ece-install.yaml* file.
 
 This profile installs the Escenic Analysis Engine, and configures it
 for production use with a sensible set of defaults.
@@ -696,6 +644,8 @@ To use this profile, add *fai\_nfs\_server\_install=1* to your
 *ece-install.conf* file.
 
 This profile installs an NFS server.
+
+This feature is not yet supported with YAML configuration files.
 
 ** <<<fai\_nfs\_client\_install>>>
 To use this profile, add *fai\_nfs\_client\_install=1* to your
@@ -712,6 +662,8 @@ fai_nfs_client_install=1
 fai_nfs_server_address=192.168.1.200
 fai_nfs_export_list="/var/exports/multimedia"
 #+END_SRC
+
+This feature is not yet supported with YAML configuration files.
 
 ** <<<fai\_vip\_install>>>
 [[file:images/nfs-vip.png]]
@@ -886,11 +838,16 @@ application servers if the profile is *editor*, *all* or
 
 To use this feature, you must define one domain for each publication
 in the following FAI parameter:
-#+BEGIN_SRC conf
-fai_publication_domain_mapping_list="
-  firepub#fire.escenic.com
-  ildpub#ild.escenic.com#feuer.escenic.com,fuego.escenic.com
-"
+#+BEGIN_SRC yaml
+profiles:
+  publications:
+    - name: firepub
+      domain: fire.escenic.com
+    - name: ildpub
+      domain: ild.escenic.com
+      aliases:
+        - feuer.example.com
+        - fuego.example.com
 #+END_SRC
 
 This will produce the following stanzas in *server.xml*:
@@ -940,11 +897,16 @@ application servers if the profile is *editor*, *all* or
 
 To use this feature, you must define one domain for each publication
 in the following FAI parameter:
-#+BEGIN_SRC conf
-fai_publication_domain_mapping_list="
-  firepub#fire.escenic.com
-  ildpub#ild.escenic.com#feuer.escenic.com,fuego.escenic.com
-"
+#+BEGIN_SRC yaml
+profiles:
+  publications:
+    - name: firepub
+      domain: fire.escenic.com
+    - name: ildpub
+      domain: ild.escenic.com
+      aliases:
+        - feuer.example.com
+        - fuego.example.com
 #+END_SRC
 
 This will produce the following stanzas in *server.xml*:
@@ -1011,322 +973,9 @@ If you do not want ece-install to touch your */etc/hosts*, you can set
 
 ** Overview of All Configuration Parameters
 The *ece-install* command understands the following settings in
-the *ece-install.conf*:
+the *ece-install.yaml*:
 
-- *technet\_user* and *technet\_password* The user name and password
-  used to access Technet for downloading Escenic software.
-
-- *wf\_user* and *wf\_password* The user name and password used for
-  downloading the Widget Framework.
-
-- *keep\_off\_wget\_user\_agent* Whenever *ece-install* uses *wget* to
-  download software, *ece-install* will add something to the user
-  agent string of *wget* so that it's possible to identify what
-  the *ece-install* command downloads. If you wish to turn this
-  feature off, set this to *0*.
-
-- *fai\_server\_java\_version* The java version to use.
-  Only allowable values are 1.6 and 1.7.
-  The default is 1.6
-
-- *fai\_all\_conf\_archive* :: *conf.tar.gz* to use for Nursery & JAAS
-     configuration. Default is "".
-
-- *fai\_all\_ear* :: EAR to use instead of the Escenic
-     binaries. Default is "".
-
-- *fai\_all\_install* :: Install all components on your
-     server.. Default is 0.
-
-- *fai\_all\_name* :: Instance name for the all install
-     server.. Default is engine1.
-
-- *fai\_all\_stop\_and\_clear* :: After installation, stop the
-     instance and clear its work & log files.. Default is 0.
-
-- *fai\_analysis\_db\_host* :: For the EAE DB (different from
-     ECE's). Default is localhost.
-
-- *fai\_analysis\_db\_install* :: Install DB profile. Default is 0.
-
-- *fai\_analysis\_db\_password* :: For the EAE DB (different from
-     ECE's). Default is read-the-source-luke.
-
-- *fai\_analysis\_db\_port* :: For the EAE DB (different from
-     ECE's). Default is 3306.
-
-- *fai\_analysis\_db\_schema* :: For the EAE DB (different from
-     ECE's). Default is ece5db.
-
-- *fai\_analysis\_db\_user* :: For the EAE DB (different from
-     ECE's). Default is ece5user.
-
-- *fai\_analysis\_heap\_size* :: The JVM heap size in megabytes. The
-     default is *2048*.
-
-- *fai\_analysis\_install* :: Will install the Escenic Analysis
-     Engine, aka Stats, EAE.. Default is 0.
-
-- *fai\_analysis\_name* :: EAE instance name. Default is analysis1.
-
-- *fai\_analysis\_port* :: Port of the EAE. Default is 8080.
-
-- *fai\_analysis\_shutdown* :: Shutdown port for the EAE app
-     server. Default is 8005.
-
-- *fai\_analysis\_stop\_and\_clear* :: After installation, stop the
-     instances and clear its work & log files. Default is 0.
-
-- *fai\_apt\_escenic\_pool* :: Which package pool in the Escenic APT to
-     install package from.. Default is stable.
-
-- *fai\_cache\_backends* :: Space separated, e.g. "app1:8080
-     app2:8080". Default is ${HOSTNAME}:8080.
-
-- *fai\_cache\_install* :: Install cache server profile. Default is 0.
-
-- *fai\_db\_daily\_backup* :: Sets up daily backup of the DB.. Default
-     is 0.
-
-- *fai\_db\_drop\_old\_db\_first* :: Warning: this will drop the old
-     database before installing a new one. Default is 0.
-
-- *fai\_db\_host* :: Useful for editor & presentation
-     profiles. Default is *$HOSTNAME*.
-
-- *fai\_db\_install* :: Install db profile. Default is 0.
-
-- *fai\_db\_password* :: Useful for DB installation profile. Default
-     is read-the-source-luke.
-
-- *fai\_db\_port* :: Useful for editor & presentation
-     profiles. Default is 3306.
-
-- *fai\_db\_schema* :: Useful for DB installation profile. Default is
-     ece5db.
-
-- *fai\_db\_user* :: Useful for DB installation profile. Default is
-     ece5user.
-
-- *fai\_dry\_run* :: ece-install will download Escenic archives and
-     install OS packages, but will not configure anything.. Default
-     is 0.
-
-- *fai\_editor\_conf\_archive* :: *conf.tar.gz* :: to use for Nursery
-     & JAAS configuration. Default is "".
-
-- *fai\_editor\_deploy\_white\_list* :: The list of WARs to be
-     deployed on this instance.. Default is "escenic-admin escenic
-     studio indexer-webservice webservice".
-
-- *fai\_editor\_ear* :: EAR to use instead of the Escenic
-     binaries. Default is "".
-
-- *fai\_editor\_heap\_size* :: The JVM heap size in megabytes. The
-     default is *2048*.
-
-- *fai\_editor\_install* :: Install the editorial profile. Default
-     is 0.
-
-- *fai\_editor\_name* :: Name of the editor instance. Default is
-     editor1.
-
-- *fai\_editor\_port* :: HTTP port of the editor instance. Default
-     is 8080.
-
-- *fai\_editor\_shutdown* :: Shutdown port of the editor
-     instance. Default is 8005.
-
-- *fai\_editor\_stop\_and\_clear* :: After installation, stop the
-     instances and clear its work & log files. Default is 0.
-
-- *fai\_enabled* :: Whether or not to run ece-install in FAI
-                    mode. Default is 0.
-
-- *fai\_keep\_off\_etc\_hosts* :: Set this to 1 if you don't
-     want *ece-install* adding entries to */etc/hosts*. Default is 0.
-
-- *fai\_monitoring\_admin\_password* :: The admin password of the web
-     interface(s). Currenlty only set for Icinga.. Default is No
-     telling you here ;-).
-
-- *fai\_monitoring\_ece\_host\_list* :: Hosts running one or more ECE
-     instance. Default is "".
-
-- *fai\_monitoring\_host\_list* :: Quoted, space separated list of
-     <host>#<ip> pairs, e.g.:
-     #+BEGIN_SRC text
-     pres1#10.72.227.250
-     pres2#10.72.227.251.
-     #+END_SRC
-     Default is "".
-
-- *fai\_monitoring\_install* :: Install the monitoring server
-     profile.. Default is 0.
-
-- *fai\_monitoring\_munin\_node\_list* :: Set this to a whitespace
-     separated list of nodes that munin should monitor. Default is "".
-
-- *fai\_monitoring\_search\_host\_list* :: Hosts running search
-     instance(s) (Solr + indexer). Default is "".
-
-- *fai\_monitoring\_server\_ip* :: The IP of the monitoring
-     server.. Default is *127.0.0.1*.
-
-- *fai\_nfs\_allowed\_client\_network* :: IP/netmask of allowed NFS
-     clients, example: *192.168.1.0/255.255.255.0*. Default is "".
-
-- *fai\_nfs\_client\_install* :: Installs an NFS client. Default is 0.
-
-- *fai\_nfs\_client\_mount\_point\_parent* :: Mount point parent
-     directory. Default is */mnt*.
-
-- *fai\_nfs\_export\_list* :: Space separated list of NFS export
-     directories, full paths as seen on the NFS server.. Default is
-     "".
-
-- *fai\_nfs\_server\_address* :: Address of the NFS server, useful for
-     the NFS client profile. Default is "".
-
-- *fai\_nfs\_server\_install* :: Install an NFS server. Default is 0.
-
-- *fai\_presentation\_conf\_archive* :: *conf.tar.gz* :: to use for
-     Nursery & JAAS configuration. Default is "".
-
-- *fai\_presentation\_ear* :: EAR to use instead of the Escenic
-     binaries. Default is "".
-
-- *fai\_presentation\_heap\_size* :: The JVM heap size in megabytes. The
-     default is *2048*.
-
-- *fai\_presentation\_install* :: Install the presentation server
-     profile. Default is 0.
-
-- *fai\_presentation\_name* :: Name of the presentation server
-     instance. Default is engine1.
-
-- *fai\_presentation\_port* :: HTTP port of the presentation server
-     instance. Default is 8080.
-
-- *fai\_presentation\_deploy\_white\_list* :: The list of WARs to be
-     deployed on this instance.. Default is "escenic-admin".
-
-- *fai\_presentation\_shutdown* :: Shutdown port of the presentation
-     instance. Default is 8005.
-
-- *fai\_presentation\_stop\_and\_clear* :: After installation, stop
-     the instances and clear its work & log files. Default is 0.
-
-- *fai\_public\_host\_name* :: The public address for your
-     website. Default is *${HOSTNAME}:8080*.
-
-- *fai\_publication\_create* :: Create a new publication. Default
-     is 0.
-
-- *fai\_publication\_domain\_mapping\_list* :: Mapping between
-     publications and domains:
-     #+BEGIN_SRC text
-     "<pub>[,pub.war]#<domain>[#,<alias1>,<alias2>]"
-     #+END_SRC
-     Default is "".
-
-- *fai\_publication\_ear* :: All publications WARs inside will be used
-     for publication creation
-     (requires that *fai\_publication\_create* is 1). Default is "".
-
-- *fai\_publication\_environment* :: The kind of
-     environment/habitat. Typical values are: production, staging,
-     testing, development.. Default is "production".
-
-- *fai\_publication\_name* :: Name of the publication. Default
-     is *mypub*. When installing an editorial or presentation server
-     and not using an EAR, you can specify *fai\_publication\_name*
-     and *fai\_publication\_war* to have *ece-install* set up the
-     correct publication definition for your Assembly Tool
-     environment.
-
-- *fai\_publication\_use\_instance* :: Name of local instance to use
-     for creation. Default is *engine1*.
-
-- *fai\_publication\_war* :: WAR to base the new publication
-     on. Default is WF demo WAR (if present) or the ECE demo
-     WAR. When installing an editorial or presentation server and
-     not using an EAR, you can specify *fai\_publication\_name*
-     and *fai\_publication\_war* to have *ece-install* set up the
-     correct publication definition for your Assembly Tool environment.
-
-- *fai\_publication\_war\_remove\_file\_list* :: File list that should
-     be removed from all WARs inside *fai\_publication\_ear*
-     or *fai\_publication\_war*. Default is "".
-
-- *fai\_rmi\_install* :: Install the RMI hub profile. Default is 0.
-
-- *fai\_search\_conf\_archive* :: *conf.tar.gz* :: to use for Nursery
-     & JAAS configuration. Default is "".
-
-- *fai\_search\_deploy\_white\_list* :: The list of WARs to be
-     deployed on this instance.. Default is "solr indexer-webapp".
-
-- *fai\_search\_ear* :: EAR to use instead of the Escenic
-     binaries. Default is "".
-
-- *fai\_search\_for\_editor* :: If 1, will configure Solr for use with
-     an editorial server, if not for presentation servers.. Default
-     is 0.
-
-- *fai\_search\_heap\_size* :: The JVM heap size in megabytes. The
-     default is *2048*.
-
-- *fai\_search\_indexer\_ws\_uri* :: URI of the indexer-webservice
-     that the search instance shall use for knowing what to
-     index.. Default is
-     http://${HOSTNAME}:8080/indexer-webservice/index/.
-
-- *fai\_search\_install* :: Install the search server profile (Solr +
-     indexer). Default is 0.
-
-- *fai\_search\_name* :: Name of the search instance. Default is
-     search1.
-
-- *fai\_search\_port* :: HTTP port of the search instance. Default
-  is 8080.
-
-- *fai\_search\_shutdown* :: Shutdown port of the search
-  instance. Default is 8005.
-
-- *fai\_vip\_address* :: The virtual IP the provider will
-     claim. Default is "".
-
-- *fai\_vip\_install* :: Install a VIP provider. Default is 0.
-
-- *fai\_vip\_primary\_node\_auth\_key* :: Optional, but useful to set
-     to make conf files consistent. Will be generated if not
-     set. Default is "".
-
-- *fai\_vip\_primary\_node\_ip* :: Primary node IP. Default is "".
-
-- *fai\_vip\_primary\_node\_name* :: Primary node name, must be what
-     $(uname -n) returns. Default is "".
-
-- *fai\_vip\_secondary\_node\_ip* :: Secondary node IP. Default is "".
-
-- *fai\_vip\_secondary\_node\_name* :: Secondary node name, must be
-     what $(uname -n) returns. Default is "".
-
-- *fai\_vip\_service\_list* :: List of init.d scripts to invoke when
-     the VIP is acclaimed/revoked, script must support start &
-     stop. Default is "".
-
-- *fai\_vip\_sibling\_ip* :: The IP of the other node offering the
-  VIP. Default is "".
-
-- *fai\_wf\_install* :: Install Widget Framework profile. Default is 0.
-
-- *fallback\_tomcat\_url* :: Override url used to download Tomcat. As old
-    releases are removed from Tomcat download mirrors this can be used to
-    point to the updated versions. Use the link for the .tar.gz file.
-
-As you've probably already found out, *0* means "false" and *1* means "true".
+#+include: "ece-install-conf-reference.org"
 
 ** Example Configurations
 Here are a few simple example configurations, you can find more under
@@ -1337,26 +986,32 @@ Here are a few simple example configurations, you can find more under
 To automatically install an editorial server and create a publication
 called "jollygood", run *ece-install* with the following settings:
 
-#+BEGIN_SRC conf
-fai_editor_install=1
-fai_publication_create=1
-fai_publication_name=jollygood
+#+BEGIN_SRC yaml
+profiles:
+  editor:
+    install: true
+  publications:
+    - name: jollygood
+      create: true
 #+END_SRC
 
 ****** Install Two Presentation Servers On a Single Host
 To install two presentation servers called *engine1* and
 *engine2* on the same host,  first run *ece-install* with the following settings:
-#+BEGIN_SRC conf
-fai_presentation_install=1
-fai_presentation_name=engine1
+#+BEGIN_SRC yaml
+profiles:
+  presentation:
+    install: true
 #+END_SRC
 
 Then run it a second time with the following settings:
-#+BEGIN_SRC conf
-fai_presentation_install=1
-fai_presentation_name=engine2
-fai_presentation_port=8081
-fai_presentation_shutdown=8105
+#+BEGIN_SRC yaml
+profiles:
+  presentation:
+    install: true
+    name: engine2
+    port: 8081
+    shutdown: 8105
 #+END_SRC
 More parameters are required the second time. On the first run,
 defaults could be used, but the second time you need to override the
@@ -1404,7 +1059,7 @@ bundle, see the FAI section.
 * Using a Custom Configuration File for ece-install
 You can specify a different configuration by using the -f parameter:
 #+BEGIN_SRC text
-# ece-install -f ece-install-presentation-server.conf
+# ece-install -f ece-install-presentation-server.yaml
 #+END_SRC
 
 * Overview of File Paths Used by the ece-install command
@@ -1479,7 +1134,7 @@ but these should be the most interesting ones.
 
 * Overriding the Escenic directories
 All of the Escenic specific directories may be overwritten in
-ece-install.conf. Here's an example of changing all the paths possible
+=ece-install.conf=. Here's an example of changing all the paths possible
 with the same suffix.
 
 #+BEGIN_SRC conf
@@ -1502,6 +1157,9 @@ test environment and want to separate stacks of Escenic Content Engine
 and plugins. Another usecase is if you want to test out a new minor
 version of ECE, e.g. you're currently running 5.4, but want to try
 out 5.5 in parallel on the same boxes.
+
+This feature is currently only available through the use of
+=.conf= configuration files.
 
 * Extending ece-install by Writing Hooks
 ece-install  has a number of hooks on which you can hook on your own
@@ -1549,60 +1207,6 @@ install_analysis_server.preinst
 install_analysis_server.postinst
 set_up_solr.preinst
 set_up_solr.postinst
-#+END_SRC
-
-* Uninstalling Everything that the ece-install Set Up
-#+BEGIN_QUOTE
-WARNING: this is potentially dangerous as some of these components may
-be used by other pieces of software you have running on your
-host. However, this may be useful if you're installing a clean
-environment and want to e.g. undo your previous install to install a
-different profile.
-#+END_QUOTE
-
-You trigger this by setting the following in your *ece-install.conf*:
-#+BEGIN_SRC conf
-fai_un_install_everything=1
-#+END_SRC
-
-*ece-install* will then prompt the user to type a confirmation
-sentence. Once the un-installation is done, a summary is printed to
-the user.
-
-*ece-install* will then continue with the other tasks and installation
-profiles if so defined. The fai_un_install_everything=1 is processed
-before any other FAI profile, hence, on a system where you want to
-wipe the slate clean before starting over, you can for instance do:
-
-#+BEGIN_SRC conf
-fai_un_install_everything=1
-fai_presentation_install=1
-#+END_SRC
-
-The output will be similar to:
-#+BEGIN_SRC text
-[ece-install-5] You have set fai_un_install_everything=1 in your
-  /root/ece-install.conf
-[ece-install-5] This will uninstall the following on raven:
-[ece-install-5] Packages to be removed: ant ant-contrib
-  ant-optional escenic-content-engine-scripts
-  escenic-munin-plugins escenic-munin-plugins libmysql-java maven2
-  memcached munin munin-node munin-plugins-extra
-  munin-java-extra nginx percona-server-client
-  percona-server-client-5.5 percona-server-common-5.5
-  percona-server-server percona-server-server-5.5
-  varnish sun-java6-jdk
-[ece-install-5] Files & directories to be removed: /etc/escenic
-  /opt/*tomcat* /opt/escenic /var/lib/escenic /var/run/escenic
-/etc/escenic /var/log/escenic /etc/apt/sources.list.d/escenic.list
-[ece-install-5] APT keys to be removed: C4DEFFEB CD2EFD2A
-[ece-install-5] If you're absolutely sure about this, type:
-[ece-install-5] I know what I'm doing, please do as I say.
-I know what I'm doing, please do as I say.
-[ece-install-11] OK, I'll do as you wish:
-[ece-install-11] I will uninstall everything from ece-install
-[ece-install-11] Everything (well, most) set up by ece-install
-[ece-install-11] should now have been removed from raven.
 #+END_SRC
 
 * GOALS & DESIGN CHOICES
@@ -1770,7 +1374,7 @@ using *ece-install*.
 Torstein Krause Johansen, Erik Mogsensen
 
 * COPYRIGHT
-Copyright 2011-2015 Escenic
+Copyright 2011-2017 Escenic
 
 Licensed under the Apache License, Version 2.0, see
 https://github.com/escenic/ece-scripts/COPYING for further details.


### PR DESCRIPTION
- Updated supported distro list + removed interactive mode doc

- Generated YAML (and conf) reference + updated (parts of) doc to use YAML

- Added a header to explain to the reader why the doc looks so spartan

- Removed duplicate db test + re-arranged tests since we generate doc
  from the tests, the most important ones should come at the
  top/logical order.

- Removed doc on un-install everything in this day and age of
  automatic provisioning/installation, a restore or clean slate
  re-install is just a click away

- Removed a reference to the RMI hub, we don't use that anymore