### PR TITLE
Fix the java jdk download to use only one url when several are available

### DIFF
--- a/usr/share/escenic/ece-scripts/ece-install.d/java.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/java.sh
@@ -12,6 +12,8 @@ function _java_get_oracle_tarball_url() {
     grep "$(uname -s) x64" |
     grep .tar.gz |
     grep -v demos |
+    sort -r |
+    head -n1 |
     sed -n -r  's#.*filepath":"(.*)", "MD5".*#\1#p'
 }
 
@@ -25,6 +27,8 @@ function _java_get_oracle_rpm_url() {
     grep "$(uname -s) x64" |
     grep .rpm |
     grep -v demos |
+    sort -r |
+    head -n1 |
     sed -n -r  's#.*filepath":"(.*)", "MD5".*#\1#p'
 }
 


### PR DESCRIPTION
At the current stage I bumped in the issues where thre are two available
packages to download for my linux version which leasd the download
method to get two urls in one string instead of just one.
```

curl -s  "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html" |grep "$(uname -s) x64" |grep .tar.gz |grep -v demos |sed -n -r  's#.*filepath":"(.*)", "MD5".*#\1#p'
http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/jdk-8u151-linux-x64.tar.gz
http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jdk-8u152-linux-x64.tar.gz

```

Current changes should allow the script to download the latest in case
there is more than one.

```
curl -s  "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html" |grep "$(uname -s) x64" |grep .tar.gz |grep -v demos | sort -r | head -n 1 |sed -n -r  's#.*filepath":"(.*)", "MD5".*#\1#p'
http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jdk-8u152-linux-x64.tar.gz

```