### PR TITLE
VOSA-291: `ece versions' output disturbed in ECE version 6+

### DIFF
--- a/usr/local/src/unit-tests/ece-versions-test.sh
+++ b/usr/local/src/unit-tests/ece-versions-test.sh
@@ -1,0 +1,94 @@
+#! /usr/bin/env bash
+
+# by per@escenic.com
+
+test_unique_module_listings() {
+  wget() {
+    cat "$(dirname "$0")/resources/ece-6.4-version-manager-output.html"
+  }
+
+  local output
+  local expected
+  local actual
+
+  output=$(list_versions)
+  expected=$(echo "$output" | sort -u | wc -l)
+  actual=$(echo "$output" | wc -l)
+  assertEquals " Duplicate entries in module list;" "${expected}" "${actual}"
+
+  unset wget
+}
+
+test_no_html_markup() {
+  wget() {
+    cat "$(dirname "$0")/resources/ece-6.4-version-manager-output.html"
+  }
+
+  local actual
+
+  actual=$(list_versions | grep -c -i -E "</?(span|pre|li)")
+  assertEquals " HTML markup present in output;" "0" "${actual}"
+
+  unset wget
+}
+
+test_no_labels() {
+  local mock_versions
+
+  mock_versions=$(find "$(dirname "$0")"/resources -name "ece-*-version-manager-output.html" | \
+    sed 's/^.*\/ece-\([0-9]\.[0-9]\).*$/\1/')
+
+  for version in ${mock_versions}; do
+
+    wget() {
+      cat "$(dirname "$0")/resources/ece-${version}-version-manager-output.html"
+    }
+
+    local actual
+
+    actual=$(list_versions | grep -c -E '[^=]+=')
+    assertEquals " Non-version number information in output from version ${version};" "0" "${actual}"
+  done
+    
+  unset wget
+}
+
+## @override shunit2
+setUp() {
+  print() {
+    echo "$@"
+  }
+
+  get_escenic_admin_url() {
+    echo "http://localhost:8080/escenic-admin"
+  }
+  
+  set_type_port() {
+    :
+  }
+
+  # shellcheck disable=SC1090
+  source "$(dirname "$0")/../../../share/escenic/ece-scripts/ece.d/versions.sh"
+
+  export type_pid=42
+  export instance=engine1
+  export port=8080
+}
+
+## @override shunit2
+tearDown() {
+  unset print
+  unset get_escenic_admin_url
+  unset set_type_port
+
+  unset type_pid
+  unset instance
+  unset port
+}
+
+main() {
+  # shellcheck disable=SC1090
+  . "$(dirname "$0")"/shunit2/shunit2
+}
+
+main "$@"

--- a/usr/local/src/unit-tests/resources/ece-5.7-version-manager-output.html
+++ b/usr/local/src/unit-tests/resources/ece-5.7-version-manager-output.html
@@ -1,0 +1,242 @@
+
+
+
+  
+  
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<!-- Frame begins -->
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+<html>
+  <head>
+    <title>local-ece: Menu</title>
+    <link rel="stylesheet" href="/escenic-admin/images/basic.css;jsessionid=1F98DB18E719E3C8E8C502B610887210" type="text/css">
+    <link rel="SHORTCUT ICON" href="/escenic-admin/images/favicon.ico;jsessionid=1F98DB18E719E3C8E8C502B610887210">
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+         
+
+  </head>
+  
+    <script language="JavaScript1.2"><!-- 
+  function submitForm(button) {
+    if(document.forms[0]) {
+      if(document.forms[0].submitButton) {
+        document.forms[0].submitButton.value=button;
+        document.forms[0].submit();
+      } else {
+        window.location.href='/escenic-admin/do/base/forward;jsessionid=1F98DB18E719E3C8E8C502B610887210?forward=' + button;
+      }
+    } else {
+      window.location.href='/escenic-admin/do/base/forward;jsessionid=1F98DB18E719E3C8E8C502B610887210?forward=' + button;
+    }
+  }
+
+  function globalSearch(searchWord) {
+    alert("Global search has not been implemented yet.  I'm not sure what to do if you click Go. What do you think?  Tell me about it; mogsie@escenic.com");
+   /*
+    if (document.forms[0]) {
+      document.forms[0].globalSearchWord.value=searchWord;
+      document.forms[0].submitButton.value='action:/do/base/globalSearch';
+      document.forms[0].submit();
+    } else {
+      alert('unable to search for "' + searchWord + '"!');
+    }*/
+  }
+
+  var init=new Function();
+
+  // -->
+</script>
+
+
+
+<body onload="init();" topmargin="0" leftmargin="0" marginwidth="0" marginheight="0" >
+
+<table cellspacing="0" cellpadding="0" width="100%" height="100%">
+
+<tr>
+  <td valign="top" class="leftPanel">
+    <div class="nav-header">Administration</div>
+    <img src="/escenic-admin/images/nothing.gif;jsessionid=1F98DB18E719E3C8E8C502B610887210" height="1" width="180">
+    <!-- Servicing content -->
+    
+
+
+<div id="navigation">
+  <a href="/escenic-admin/;jsessionid=1F98DB18E719E3C8E8C502B610887210">Home</a><br />
+  <a href="/escenic-admin/pages/publication/list.jsp;jsessionid=1F98DB18E719E3C8E8C502B610887210">List&nbsp;publications</a><br />
+  <a href="/escenic-admin/pages/publication/new.jsp;jsessionid=1F98DB18E719E3C8E8C502B610887210">New&nbsp;publications</a><br />
+  <a href="/escenic-admin/tools.jsp;jsessionid=1F98DB18E719E3C8E8C502B610887210">Publication tools</a><br />
+</div>
+    <!-- Finished servicing content -->
+  </td>
+
+  <td valign="top" class="centerPanel">
+      
+      <!-- Servicing content -->
+      
+
+
+
+
+
+
+
+
+<h1>Component browser</h1>
+<div class="componentBrowser">
+    <h1>Scope: Global</h1>
+    
+        <h4><a href="?changeBus=true">Browse other scope</a></h4>
+    
+    <H1> Service <A href="/escenic-admin/browser/Global/"> /</A><A href="/escenic-admin/browser/Global/neo/">neo/</A><A href="/escenic-admin/browser/Global/neo/io/">io/</A><A href="/escenic-admin/browser/Global/neo/io/managers/">managers/</A><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager">VersionManager</A></H1>
+    
+    Class: <A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager">neo.xredsys.config.VersionManager</A>
+    <HR>
+    
+    <H1>Directory Listing</H1>
+<table border=0 cellspacing=3 cellpadding=3><tr>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ACLManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ACLManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/AgreementManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;AgreementManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/AlarmManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;AlarmManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleInTransformer"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleInTransformer</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleListManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleListManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleListRemovalFilter"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleListRemovalFilter</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleOutTransformer"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleOutTransformer</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/CharacterConversionConfiguration-utf8"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;CharacterConversionConfiguration-utf8</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/CharacterConversionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;CharacterConversionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ContentManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ContentManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/DatabaseResourceManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;DatabaseResourceManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/EntityManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;EntityManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ImageVersionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ImageVersionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/LayoutGroupDefinitionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;LayoutGroupDefinitionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/LayoutManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;LayoutManager</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ListDBManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ListDBManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PersonManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PersonManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PluginManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PluginManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PoolManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PoolManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PublicationManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PublicationManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/RoleManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;RoleManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/SectionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;SectionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/SectionResourceManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;SectionResourceManager</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/TypeManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;TypeManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;VersionManager</A><BR>
+</tr></table>
+<hr/>    <H1>Properties</H1>
+    <TABLE border="1">
+      <TR>
+        <TH>Name</TH><TH>Value</TH><TH>Type</TH>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=componentNames">componentNames</A></TD>
+        <TD valign='top'>[widget-framework, xmlEditor, io, nursery-search, poll, lucy, forum, live-center, newsgate, analysis-engine, geocode, menuEditor, seo, dashboard, snapshot, sectionFeed]</TD>
+        <TD valign='top'>Collection</TD>
+      </TR>
+    </TABLE>
+    <H1>Methods</H1>
+    <TABLE border="1">
+      <TR>
+        <TH>Name</TH><TH>Return Type</TH><TH>Declaring Class</TH>
+      </TR>
+      <TR>
+        <TD><A href="?map=addComponent">addComponent</A> (add)</TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getComponent">getComponent</A></TD>
+        <TD>neo.xredsys.config.VersionManager$Component</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getComponentNames">getComponentNames</A></TD>
+        <TD>Collection</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getInstance">getInstance</A></TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=registerComponent">registerComponent</A></TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=toString">toString</A></TD>
+        <TD>String</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+    </TABLE>
+    <H1>Service Information</H1>
+<ul><li class="CONFIGURATION_READ"><span class="source">jar:file:/opt/apache-tomcat-7.0.64/escenic/lib/engine-config-5.7.75.180558.jar!/com/escenic/configuration/default/neo/io/managers/VersionManager.properties</span><pre>$class=neo.xredsys.config.VersionManager
+
+component.io=5.7.75.180558</pre></li><li class="LAYERS_MERGED"><pre>#Mon Oct 30 10:17:13 UTC 2017
+$class=neo.xredsys.config.VersionManager
+component.io=5.7.75.180558
+</pre></li><li class="CONSTRUCTOR_INVOKED"><span class="method">neo.xredsys.config.VersionManager</span></li><li class="EXCEPTION_HANDLED"><span class="classname">java.lang.IllegalAccessException</span><span class="message">Class neo.nursery.PublicConstructorStrategy can not access a member of class neo.xredsys.config.VersionManager with modifiers "protected"</span></li><li class="METHOD_INVOKED"><span class="method">getInstance</span><span class="args">{}</span></li><li class="METHOD_INVOKED"><span class="method">addComponent</span><span class="args">{io,5.7.75.180558}</span></li><li class="COMPONENT_CREATED"><span class="component">/neo/io/managers/VersionManager</span></li></ul><H1>Bus configuration</H1>
+<ul><li>ResourceDepot: looking for package 'com/escenic/configuration/default/.*' in classLoader(class org.apache.catalina.loader.StandardClassLoader),</li><li>ResourceDepot: looking for package '*' in classLoader(class org.apache.catalina.loader.StandardClassLoader),</li><li>FileSystemDepot: /etc/escenic/engine/common</li><li>FileSystemDepot: /etc/escenic/engine/family/default</li><li>FileSystemDepot: /etc/escenic/engine/host/localhost</li></ul>    <H1>String Value</H1>
+    [[Name=xmlEditor; Version=2.5.0.149301], [Name=dashboard; Version=1.6.0.148670], [Name=menuEditor; Version=2.3.0.149305], [Name=geocode; Version=2.8.0.148641], [Name=nursery-search; Version=1.0.2], [Name=sectionFeed; Version=2.3.1.153084], [Name=widget-framework; Version=3.7.1.181414], [Name=forum; Version=3.4.0.148632], [Name=io; Version=5.7.75.180558], [Name=live-center; Version=1.4.0.180619], [Name=snapshot; Version=2.0.0.180467], [Name=lucy; Version=4.4.1.153407], [Name=newsgate; Version=2.4.2.167332], [Name=analysis-engine; Version=2.8.2.177967], [Name=poll; Version=2.5.3.170341], [Name=seo; Version=1.2.2.162651]]
+
+    
+    <HR>
+    (C) <script>document.write((new Date()).getFullYear());</script> Escenic AS
+
+</div>
+      <!-- Finished servicing content -->
+  </td>
+</tr>
+</table>
+
+  
+
+  
+
+  </body>
+</html>
+<!-- Frame ends -->
+

--- a/usr/local/src/unit-tests/resources/ece-6.3-version-manager-output.html
+++ b/usr/local/src/unit-tests/resources/ece-6.3-version-manager-output.html
@@ -1,0 +1,351 @@
+
+
+
+  
+  
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<!-- Frame begins -->
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+<html>
+  <head>
+    <title>dev-box: Menu</title>
+    <link rel="stylesheet" href="/escenic-admin/images/basic.css;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1" type="text/css">
+    <link rel="SHORTCUT ICON" href="/escenic-admin/images/favicon.ico;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1">
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+         
+
+  </head>
+  
+    <script language="JavaScript1.2"><!-- 
+  function submitForm(button) {
+    if(document.forms[0]) {
+      if(document.forms[0].submitButton) {
+        document.forms[0].submitButton.value=button;
+        document.forms[0].submit();
+      } else {
+        window.location.href='/escenic-admin/do/base/forward;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1?forward=' + button;
+      }
+    } else {
+      window.location.href='/escenic-admin/do/base/forward;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1?forward=' + button;
+    }
+  }
+
+  function globalSearch(searchWord) {
+    alert("Global search has not been implemented yet.  I'm not sure what to do if you click Go. What do you think?  Tell me about it; mogsie@escenic.com");
+   /*
+    if (document.forms[0]) {
+      document.forms[0].globalSearchWord.value=searchWord;
+      document.forms[0].submitButton.value='action:/do/base/globalSearch';
+      document.forms[0].submit();
+    } else {
+      alert('unable to search for "' + searchWord + '"!');
+    }*/
+  }
+
+  var init=new Function();
+
+  // -->
+</script>
+
+
+
+<body onload="init();" topmargin="0" leftmargin="0" marginwidth="0" marginheight="0" >
+
+<table cellspacing="0" cellpadding="0" width="100%" height="100%">
+
+<tr>
+  <td valign="top" class="leftPanel">
+    <div class="nav-header">Administration</div>
+    <img src="/escenic-admin/images/nothing.gif;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1" height="1" width="180">
+    <!-- Servicing content -->
+    
+
+
+<div id="navigation">
+  <a href="/escenic-admin/;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1">Home</a><br />
+  <a href="/escenic-admin/pages/publication/list.jsp;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1">List&nbsp;publications</a><br />
+  <a href="/escenic-admin/pages/publication/new.jsp;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1">New&nbsp;publications</a><br />
+  <a href="/escenic-admin/tools.jsp;jsessionid=53FB7B225C2ECE4E7E52CAB342A03F55.jvm1">Publication tools</a><br />
+</div>
+    <!-- Finished servicing content -->
+  </td>
+
+  <td valign="top" class="centerPanel">
+      
+      <!-- Servicing content -->
+      
+
+
+
+
+
+
+
+
+<h1>Component browser</h1>
+<div class="componentBrowser">
+    <h1>Scope: Global</h1>
+    
+        <h4><a href="?changeBus=true">Browse other scope</a></h4>
+    
+    <H1> Service <A href="/escenic-admin/browser/Global/"> /</A><A href="/escenic-admin/browser/Global//">/</A><A href="/escenic-admin/browser/Global//neo/">neo/</A><A href="/escenic-admin/browser/Global//neo/io/">io/</A><A href="/escenic-admin/browser/Global//neo/io/managers/">managers/</A><A href="/escenic-admin/browser/Global//neo/io/managers/VersionManager">VersionManager</A></H1>
+    
+    Class: <A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager">neo.xredsys.config.VersionManager</A>
+    <HR>
+    
+    <H1>Directory Listing</H1>
+<table border=0 cellspacing=3 cellpadding=3><tr>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ACLManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ACLManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/AgreementManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;AgreementManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/AlarmManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;AlarmManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleInTransformer"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleInTransformer</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleListManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleListManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleListRemovalFilter"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleListRemovalFilter</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleOutTransformer"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleOutTransformer</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/CharacterConversionConfiguration-utf8"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;CharacterConversionConfiguration-utf8</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/CharacterConversionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;CharacterConversionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ContentManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ContentManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/DatabaseResourceManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;DatabaseResourceManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/EntityManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;EntityManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ImageVersionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ImageVersionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/LayoutGroupDefinitionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;LayoutGroupDefinitionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/LayoutManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;LayoutManager</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ListDBManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ListDBManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PersonManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PersonManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PluginManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PluginManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PoolManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PoolManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PublicationManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PublicationManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/RoleManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;RoleManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/SectionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;SectionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/SectionResourceManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;SectionResourceManager</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/TypeManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;TypeManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;VersionManager</A><BR>
+</tr></table>
+<hr/>    <H1>Properties</H1>
+    <TABLE border="1">
+      <TR>
+        <TH>Name</TH><TH>Value</TH><TH>Type</TH>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=componentNames">componentNames</A></TD>
+        <TD valign='top'>[io, menuEditor]</TD>
+        <TD valign='top'>Collection</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=components">components</A></TD>
+        <TD valign='top'>[<a href='/escenic-admin/browser/Global/com/escenic/version/ContentEngine'>com/escenic/version/ContentEngine</a>, [Name=menuEditor; Label=The Escenic Menu Editor; Version=3.2.0-3; Sub component=plugin.xml; Description=The Menu editor is a editor in CUE used to edit &quot;menu.xml&quot; files in the publication.]]</TD>
+        <TD valign='top'>Set</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceDescription">serviceDescription</A></TD>
+        <TD valign='top'>(null)</TD>
+        <TD valign='top'>String</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceEnabled">serviceEnabled</A></TD>
+        <TD valign='top'>true</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceFailed">serviceFailed</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceIdle">serviceIdle</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceMessage">serviceMessage</A></TD>
+        <TD valign='top'>The service is running normally</TD>
+        <TD valign='top'>String</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceRunning">serviceRunning</A></TD>
+        <TD valign='top'>true</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceShutdownFailed">serviceShutdownFailed</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceStopped">serviceStopped</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+    </TABLE>
+    <H1>Methods</H1>
+    <TABLE border="1">
+      <TR>
+        <TH>Name</TH><TH>Return Type</TH><TH>Declaring Class</TH>
+      </TR>
+      <TR>
+        <TD><A href="?map=addComponent">addComponent</A> (add)</TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=doStartService">doStartService</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.AbstractNurseryService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=doStopService">doStopService</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.AbstractNurseryService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getComponent">getComponent</A></TD>
+        <TD>neo.xredsys.config.VersionManager$Component</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getComponentNames">getComponentNames</A></TD>
+        <TD>Collection</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getInstance">getInstance</A></TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getServiceDescription">getServiceDescription</A></TD>
+        <TD>String</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getServiceMessage">getServiceMessage</A></TD>
+        <TD>String</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceEnabled">isServiceEnabled</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceFailed">isServiceFailed</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceIdle">isServiceIdle</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceRunning">isServiceRunning</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceShutdownFailed">isServiceShutdownFailed</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceStopped">isServiceStopped</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=register">register</A></TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=registerComponent">registerComponent</A></TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=setServiceDescription">setServiceDescription</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=setServiceEnabled">setServiceEnabled</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=toString">toString</A></TD>
+        <TD>String</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+    </TABLE>
+    <H1>Service Information</H1>
+<ul><li class="CONFIGURATION_READ"><span class="source">jar:file:/opt/tomcat-engine1/escenic/lib/engine-config-6.3.0-11.jar!/com/escenic/configuration/default/neo/io/managers/VersionManager.properties</span><pre>$class=neo.xredsys.config.VersionManager
+components=/com/escenic/version/ContentEngine</pre></li><li class="LAYERS_MERGED"><pre>#Mon Oct 30 08:29:43 UTC 2017
+$class=neo.xredsys.config.VersionManager
+components=/com/escenic/version/ContentEngine
+</pre></li><li class="CONSTRUCTOR_INVOKED"><span class="method">neo.xredsys.config.VersionManager</span></li><li class="FIELD_INVOKED"><span class="field">components</span><span class="args">[[Name=io; Label=Escenic Content Engine; Version=6.3.0-11]]</span></li><li class="METHOD_INVOKED"><span class="method">doStartService</span><span class="args">{}</span></li><li class="COMPONENT_CREATED"><span class="component">/neo/io/managers/VersionManager</span></li></ul><H1>Bus configuration</H1>
+<ul><li>ResourceDepot: looking for package 'com/escenic/configuration/default/.*' in classLoader(class java.net.URLClassLoader),</li><li>ResourceDepot: looking for package '*' in classLoader(class java.net.URLClassLoader),</li><li>FileSystemDepot: /etc/escenic/engine/vosa</li><li>FileSystemDepot: /etc/escenic/engine/common</li><li>FileSystemDepot: /etc/escenic/engine/family/default</li><li>FileSystemDepot: /etc/escenic/engine/environment/unknown</li><li>FileSystemDepot: /etc/escenic/engine/host/dev-box</li><li>FileSystemDepot: /etc/escenic/engine/instance/engine1</li><li>FileSystemDepot: /etc/escenic/engine/server/dev-box</li></ul>    <H1>String Value</H1>
+    [[Name=io; Label=Escenic Content Engine; Version=6.3.0-11], [Name=menuEditor; Label=The Escenic Menu Editor; Version=3.2.0-3; Sub component=plugin.xml; Description=The Menu editor is a editor in CUE used to edit "menu.xml" files in the publication.]]
+
+    
+    <HR>
+    (C) <script>document.write((new Date()).getFullYear());</script> Escenic AS
+
+</div>
+      <!-- Finished servicing content -->
+  </td>
+</tr>
+</table>
+
+  
+
+  
+
+  </body>
+</html>
+<!-- Frame ends -->
+

--- a/usr/local/src/unit-tests/resources/ece-6.4-version-manager-output.html
+++ b/usr/local/src/unit-tests/resources/ece-6.4-version-manager-output.html
@@ -1,0 +1,363 @@
+
+
+
+  
+  
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<!-- Frame begins -->
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+<html>
+  <head>
+    <title>ece-fuji: Menu</title>
+    <link rel="stylesheet" href="/escenic-admin/images/basic.css;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1" type="text/css">
+    <link rel="SHORTCUT ICON" href="/escenic-admin/images/favicon.ico;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1">
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+         
+
+  </head>
+  
+    <script language="JavaScript1.2"><!-- 
+  function submitForm(button) {
+    if(document.forms[0]) {
+      if(document.forms[0].submitButton) {
+        document.forms[0].submitButton.value=button;
+        document.forms[0].submit();
+      } else {
+        window.location.href='/escenic-admin/do/base/forward;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1?forward=' + button;
+      }
+    } else {
+      window.location.href='/escenic-admin/do/base/forward;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1?forward=' + button;
+    }
+  }
+
+  function globalSearch(searchWord) {
+    alert("Global search has not been implemented yet.  I'm not sure what to do if you click Go. What do you think?  Tell me about it; mogsie@escenic.com");
+   /*
+    if (document.forms[0]) {
+      document.forms[0].globalSearchWord.value=searchWord;
+      document.forms[0].submitButton.value='action:/do/base/globalSearch';
+      document.forms[0].submit();
+    } else {
+      alert('unable to search for "' + searchWord + '"!');
+    }*/
+  }
+
+  var init=new Function();
+
+  // -->
+</script>
+
+
+
+<body onload="init();" topmargin="0" leftmargin="0" marginwidth="0" marginheight="0" >
+
+<table cellspacing="0" cellpadding="0" width="100%" height="100%">
+
+<tr>
+  <td valign="top" class="leftPanel">
+    <div class="nav-header">Administration</div>
+    <img src="/escenic-admin/images/nothing.gif;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1" height="1" width="180">
+    <!-- Servicing content -->
+    
+
+
+<div id="navigation">
+  <a href="/escenic-admin/;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1">Home</a><br />
+  <a href="/escenic-admin/pages/publication/list.jsp;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1">List&nbsp;publications</a><br />
+  <a href="/escenic-admin/pages/publication/new.jsp;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1">New&nbsp;publications</a><br />
+  <a href="/escenic-admin/tools.jsp;jsessionid=C254E075B35E242AC65CD80AAFA77050.jvm1">Publication tools</a><br />
+</div>
+    <!-- Finished servicing content -->
+  </td>
+
+  <td valign="top" class="centerPanel">
+      
+      <!-- Servicing content -->
+      
+
+
+
+
+
+
+
+
+<h1>Component browser</h1>
+<div class="componentBrowser">
+    <h1>Scope: Global</h1>
+    
+        <h4><a href="?changeBus=true">Browse other scope</a></h4>
+    
+    <H1> Service <A href="/escenic-admin/browser/Global/"> /</A><A href="/escenic-admin/browser/Global//">/</A><A href="/escenic-admin/browser/Global//neo/">neo/</A><A href="/escenic-admin/browser/Global//neo/io/">io/</A><A href="/escenic-admin/browser/Global//neo/io/managers/">managers/</A><A href="/escenic-admin/browser/Global//neo/io/managers/VersionManager">VersionManager</A></H1>
+    
+    Class: <A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager">neo.xredsys.config.VersionManager</A>
+    <HR>
+    
+    <H1>Directory Listing</H1>
+<table border=0 cellspacing=3 cellpadding=3><tr>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ACLManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ACLManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/AgreementManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;AgreementManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/AlarmManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;AlarmManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleInTransformer"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleInTransformer</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleListManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleListManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleListRemovalFilter"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleListRemovalFilter</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ArticleOutTransformer"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ArticleOutTransformer</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/CharacterConversionConfiguration-utf8"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;CharacterConversionConfiguration-utf8</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/CharacterConversionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;CharacterConversionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ContentManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ContentManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/DatabaseResourceManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;DatabaseResourceManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/EntityManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;EntityManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ImageVersionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ImageVersionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/LayoutGroupDefinitionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;LayoutGroupDefinitionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/LayoutManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;LayoutManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/ListDBManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;ListDBManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PersonManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PersonManager</A><BR>
+<td style="border-bottom: none;" valign=top>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PluginManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PluginManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PoolManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PoolManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/PublicationManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;PublicationManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/RoleManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;RoleManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/SectionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;SectionManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/SectionResourceManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;SectionResourceManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/TemplateManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;TemplateManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/TypeManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;TypeManager</A><BR>
+<A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager"><img src='/escenic-admin/images/file.gif' border=0>&nbsp;VersionManager</A><BR>
+</tr></table>
+<hr/>    <H1>Properties</H1>
+    <TABLE border="1">
+      <TR>
+        <TH>Name</TH><TH>Value</TH><TH>Type</TH>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=componentNames">componentNames</A></TD>
+        <TD valign='top'>[widget-framework, note, newsgate-tag-editor, io, poll, video, lucy, newsgate, analysis-engine, newsgate-geo-editor, geocode, socialmediapublishing, semantic-cXense, menuEditor, seo, live, sectionFeed]</TD>
+        <TD valign='top'>Collection</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=components">components</A></TD>
+        <TD valign='top'>[[Name=lucy; Label=Escenic Lucy plugin; Version=5.1.0-2; Sub component=plugin.xml; Description=The Lucy plugin], [Name=poll; Label=Escenic Poll plugin; Version=3.2.0-1; Sub component=plugin.xml; Description=The Poll plugin], [Name=live; Label=The Escenic Content Engine Live; Version=2.5.0-1; Sub component=plugin.xml; Description=Live], [Name=widget-framework; Label=Widget Framework; Version=4.2.0-2; Sub component=plugin.xml; Description=Widget Framework Plug-in], [Name=newsgate-geo-editor; Label=Newsgate geo editor plugin; Version=1.0; Sub component=plugin.xml; Description=Newsgate geo editor plugin], [Name=video; Label=The Escenic Video Module; Version=4.5.0-2; Sub component=plugin.xml; Description=The Video module enables users to use video in Content Studio], [Name=newsgate; Label=newsgate plugin; Version=3.1.0-4; Sub component=plugin.xml; Description=
+    This plugin adds a two-way integration with cci and newsgate
+  ], [Name=sectionFeed; Label=The Escenic Content Engine Section Feed editor; Version=3.0.0-5; Sub component=plugin.xml; Description=The Section feed is a web interface used to edit &quot;section-feed&quot; resources in publications.], [Name=newsgate-tag-editor; Label=Newsgate tag editor plugin; Version=1.0; Sub component=plugin.xml; Description=Newsgate tag editor plugin], [Name=socialmediapublishing; Label=SocialMediaPublishing plugin; Version=2.0; Sub component=plugin.xml; Description=
+        This plugin adds integration to Twitter and Facebook
+    ], [Name=semantic-cXense; Label=The Escenic Semantic cXense Module; Version=2.0.0-4; Sub component=plugin.xml; Description=The Semantic cXense module enables users to do semantic analysis using cXense in Content Studio], [Name=note; Label=The Escenic Note Module; Version=2.0.0-4; Sub component=plugin.xml; Description=The Note module enables users to annotate content in Content Studio], [Name=geocode; Label=Escenic Geocode Plugin; Version=3.1.0-1; Sub component=plugin.xml; Description=
+    The plug-in allows the users to tag the content-items of the Escenic Content Engine with geo information.
+  ], [Name=menuEditor; Label=The Escenic Menu Editor; Version=3.3.0-2; Sub component=plugin.xml; Description=The Menu editor is a editor in CUE used to edit &quot;menu.xml&quot; files in the publication.], [Name=analysis-engine; Label=The Escenic Analysis Engine plugin; Version=3.0.1-1; Sub component=plugin.xml; Description=The EAE plugin allows escenic to retrieve statistical information from the EAE.], [Name=seo; Label=Escenic Search Engine Optimization Module; Version=2.1.0-3; Sub component=plugin.xml; Description=The SEO module ], <a href='/escenic-admin/browser/Global/com/escenic/version/ContentEngine'>com/escenic/version/ContentEngine</a>]</TD>
+        <TD valign='top'>Set</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceDescription">serviceDescription</A></TD>
+        <TD valign='top'>(null)</TD>
+        <TD valign='top'>String</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceEnabled">serviceEnabled</A></TD>
+        <TD valign='top'>true</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceFailed">serviceFailed</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceIdle">serviceIdle</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceMessage">serviceMessage</A></TD>
+        <TD valign='top'>The service is running normally</TD>
+        <TD valign='top'>String</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceRunning">serviceRunning</A></TD>
+        <TD valign='top'>true</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceShutdownFailed">serviceShutdownFailed</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+      <TR>
+        <TD valign='top'><A href="/escenic-admin/browser/Global/neo/io/managers/VersionManager?property=serviceStopped">serviceStopped</A></TD>
+        <TD valign='top'>false</TD>
+        <TD valign='top'>boolean</TD>
+      </TR>
+    </TABLE>
+    <H1>Methods</H1>
+    <TABLE border="1">
+      <TR>
+        <TH>Name</TH><TH>Return Type</TH><TH>Declaring Class</TH>
+      </TR>
+      <TR>
+        <TD><A href="?map=addComponent">addComponent</A> (add)</TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=doStartService">doStartService</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.AbstractNurseryService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=doStopService">doStopService</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.AbstractNurseryService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getComponent">getComponent</A></TD>
+        <TD>neo.xredsys.config.VersionManager$Component</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getComponentNames">getComponentNames</A></TD>
+        <TD>Collection</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getInstance">getInstance</A></TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getServiceDescription">getServiceDescription</A></TD>
+        <TD>String</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=getServiceMessage">getServiceMessage</A></TD>
+        <TD>String</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceEnabled">isServiceEnabled</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceFailed">isServiceFailed</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceIdle">isServiceIdle</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceRunning">isServiceRunning</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceShutdownFailed">isServiceShutdownFailed</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=isServiceStopped">isServiceStopped</A></TD>
+        <TD>boolean</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=register">register</A></TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=registerComponent">registerComponent</A></TD>
+        <TD>void</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=setServiceDescription">setServiceDescription</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=setServiceEnabled">setServiceEnabled</A></TD>
+        <TD>void</TD>
+        <TD>neo.nursery.GenericService</TD>
+      </TR>
+      <TR>
+        <TD><A href="?method=toString">toString</A></TD>
+        <TD>String</TD>
+        <TD>neo.xredsys.config.VersionManager</TD>
+      </TR>
+    </TABLE>
+    <H1>Service Information</H1>
+<ul><li class="CONFIGURATION_READ"><span class="source">jar:file:/opt/tomcat-engine1/escenic/lib/engine-config-6.4.0-1.jar!/com/escenic/configuration/default/neo/io/managers/VersionManager.properties</span><pre>$class=neo.xredsys.config.VersionManager
+components=/com/escenic/version/ContentEngine</pre></li><li class="LAYERS_MERGED"><pre>#Fri Oct 27 14:23:18 GMT 2017
+$class=neo.xredsys.config.VersionManager
+components=/com/escenic/version/ContentEngine
+</pre></li><li class="CONSTRUCTOR_INVOKED"><span class="method">neo.xredsys.config.VersionManager</span></li><li class="FIELD_INVOKED"><span class="field">components</span><span class="args">[[Name=io; Label=Escenic Content Engine; Version=6.4.0-1]]</span></li><li class="METHOD_INVOKED"><span class="method">doStartService</span><span class="args">{}</span></li><li class="COMPONENT_CREATED"><span class="component">/neo/io/managers/VersionManager</span></li></ul><H1>Bus configuration</H1>
+<ul><li>ResourceDepot: looking for package 'com/escenic/configuration/default/.*' in classLoader(class java.net.URLClassLoader),</li><li>ResourceDepot: looking for package '*' in classLoader(class java.net.URLClassLoader),</li><li>FileSystemDepot: /etc/escenic/engine/vosa</li><li>FileSystemDepot: /etc/escenic/engine/common</li><li>FileSystemDepot: /etc/escenic/engine/family/default</li><li>FileSystemDepot: /etc/escenic/engine/environment/ece-fuji</li><li>FileSystemDepot: /etc/escenic/engine/host/ece-fuji</li><li>FileSystemDepot: /etc/escenic/engine/instance/engine1</li><li>FileSystemDepot: /etc/escenic/engine/server/ece-fuji</li></ul>    <H1>String Value</H1>
+    [[Name=lucy; Label=Escenic Lucy plugin; Version=5.1.0-2; Sub component=plugin.xml; Description=The Lucy plugin], [Name=poll; Label=Escenic Poll plugin; Version=3.2.0-1; Sub component=plugin.xml; Description=The Poll plugin], [Name=live; Label=The Escenic Content Engine Live; Version=2.5.0-1; Sub component=plugin.xml; Description=Live], [Name=widget-framework; Label=Widget Framework; Version=4.2.0-2; Sub component=plugin.xml; Description=Widget Framework Plug-in], [Name=newsgate-geo-editor; Label=Newsgate geo editor plugin; Version=1.0; Sub component=plugin.xml; Description=Newsgate geo editor plugin], [Name=video; Label=The Escenic Video Module; Version=4.5.0-2; Sub component=plugin.xml; Description=The Video module enables users to use video in Content Studio], [Name=newsgate; Label=newsgate plugin; Version=3.1.0-4; Sub component=plugin.xml; Description=
+    This plugin adds a two-way integration with cci and newsgate
+  ], [Name=sectionFeed; Label=The Escenic Content Engine Section Feed editor; Version=3.0.0-5; Sub component=plugin.xml; Description=The Section feed is a web interface used to edit "section-feed" resources in publications.], [Name=newsgate-tag-editor; Label=Newsgate tag editor plugin; Version=1.0; Sub component=plugin.xml; Description=Newsgate tag editor plugin], [Name=socialmediapublishing; Label=SocialMediaPublishing plugin; Version=2.0; Sub component=plugin.xml; Description=
+        This plugin adds integration to Twitter and Facebook
+    ], [Name=semantic-cXense; Label=The Escenic Semantic cXense Module; Version=2.0.0-4; Sub component=plugin.xml; Description=The Semantic cXense module enables users to do semantic analysis using cXense in Content Studio], [Name=note; Label=The Escenic Note Module; Version=2.0.0-4; Sub component=plugin.xml; Description=The Note module enables users to annotate content in Content Studio], [Name=geocode; Label=Escenic Geocode Plugin; Version=3.1.0-1; Sub component=plugin.xml; Description=
+    The plug-in allows the users to tag the content-items of the Escenic Content Engine with geo information.
+  ], [Name=menuEditor; Label=The Escenic Menu Editor; Version=3.3.0-2; Sub component=plugin.xml; Description=The Menu editor is a editor in CUE used to edit "menu.xml" files in the publication.], [Name=analysis-engine; Label=The Escenic Analysis Engine plugin; Version=3.0.1-1; Sub component=plugin.xml; Description=The EAE plugin allows escenic to retrieve statistical information from the EAE.], [Name=seo; Label=Escenic Search Engine Optimization Module; Version=2.1.0-3; Sub component=plugin.xml; Description=The SEO module ], [Name=io; Label=Escenic Content Engine; Version=6.4.0-1]]
+
+    
+    <HR>
+    (C) <script>document.write((new Date()).getFullYear());</script> Escenic AS
+
+</div>
+      <!-- Finished servicing content -->
+  </td>
+</tr>
+</table>
+
+  
+
+  
+
+  </body>
+</html>
+<!-- Frame ends -->
+

--- a/usr/share/escenic/ece-scripts/ece.d/versions.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/versions.sh
@@ -12,12 +12,13 @@ function list_versions() {
   
   print "Installed on the ${instance} instance running on port ${port}:"
   wget --timeout 30 $wget_opts $wget_appserver_auth -O - $url  2>/dev/null | \
-    grep "\[\[" | \
-    sed 's/\[//g' | \
-    sed 's/\]//g' | \
+    sed '1,/String Value/d' | sed '/<HR>/,$d' | \
+    tr -d '\n' | \
     sed 's/Name\=io/Name\=content-engine/g' | \
     sed 's/Name\=//g' | \
-    sed 's/\;\ Version\=/\ /g' | \
+    sed 's/;[^]]* Version=\([^];]*\)[^]]*/ \1/g' | \
+    sed 's/\[//g' | \
+    sed 's/\]//g' | \
     awk -F',' '{for (i = 1; i <= NF; i++) print "   * " $i;}' | \
     sed 's/\*\ \ \ /\*/g' | \
     sort


### PR DESCRIPTION
The implementation in versions.sh is modified to focus on the string value of the VersionManager component page (fixes HTML markup and duplication) and to remove properties other than the version number (fixes labels in the output).

Discussion probably needed on the way I mocked the environment for the list_versions() function (especially the mock of the `wget' command) in the test-ece-versions.sh script.