### PR TITLE
VOSA-319 Tomcat 9 support

### DIFF
--- a/usr/share/escenic/ece-scripts/common-os.sh
+++ b/usr/share/escenic/ece-scripts/common-os.sh
@@ -47,7 +47,12 @@ function get_user_home_directory() {
 ## Will return 1 if the system has Sun/Oracle Java installed.
 function has_oracle_java_installed() {
   local java_bin_list=$(
-    find /usr/lib/jvm -maxdepth 3 -name java -type f -executable)
+    find /usr/lib/jvm \
+         -maxdepth 3 \
+         -name java \
+         -type f \
+         -executable \
+         2>/dev/null)
 
   for java_bin in ${java_bin_list}; do
     local hit=$(${java_bin} -version 2>&1 > /dev/null | grep HotSpot | wc -l)
@@ -140,7 +145,7 @@ function get_tomcat_download_url() {
     url=$tomcat_download
   else
     url=$(
-        curl -s http://tomcat.apache.org/download-70.cgi | \
+        curl -s http://tomcat.apache.org/download-90.cgi | \
             grep tar.gz | \
             head -1 | \
             cut -d'"' -f2

--- a/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
@@ -149,7 +149,6 @@ function set_up_app_server() {
 <?xml version='1.0' encoding='utf-8'?>
 <Server port="$shutdown_port" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <Listener className="org.apache.catalina.core.JasperListener" />
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
 
@@ -315,7 +314,7 @@ EOF
   cat >> $tomcat_base/conf/server.xml <<EOF
     <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
       <Valve className="org.apache.catalina.valves.AccessLogValve"
-             prefix="access."
+             prefix="access"
              suffix=".log"
              pattern="common"/>
       <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
@@ -345,7 +344,7 @@ EOF
                />
     <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
       <Valve className="org.apache.catalina.valves.AccessLogValve"
-             prefix="access-publications."
+             prefix="access-publications"
              suffix=".log"
              pattern="common"
              />
@@ -478,8 +477,6 @@ EOF
 
 function set_up_logging() {
   print_and_log "Setting up Tomcat to use log4j ..."
-  log4j_download_the_tomcat_juli_libraries_and_copy_these_to_cl
-  log4j_ensure_java_util_logging_is_not_doing_anything
   log4j_create_configuration_file
 }
 
@@ -601,30 +598,3 @@ EOF
   fi
 }
 
-## libraries needed for overriding the default logging framework in
-## Tomcat.
-function log4j_download_the_tomcat_juli_libraries_and_copy_these_to_cl() {
-  log "Downloading Tomcat libraries to override java.util.Logging ..."
-  local libraries="tomcat-juli-adapters.jar tomcat-juli.jar"
-  local tomcat_base_uri=$(dirname $(get_tomcat_download_url))
-  for el in $libraries; do
-    download_uri_target_to_dir \
-      $tomcat_base_uri/extras/$el \
-      $download_dir
-    local file=$download_dir/$(basename $el)
-  done
-
-  run cp $download_dir/tomcat-juli-adapters.jar $tomcat_home/lib/
-  run cp $download_dir/tomcat-juli.jar $tomcat_home/bin/
-  # we don't copy the log4j JAR as this is provided with ECE and EAE.
-}
-
-function log4j_ensure_java_util_logging_is_not_doing_anything() {
-  log "Ensure java.util.Logging is put to rest ..."
-  local file=$tomcat_base/conf/logging.properties
-  if [ -e $file ]; then
-    run rm $file
-  else
-    log $file "doesn't exist, strange"
-  fi
-}


### PR DESCRIPTION
- ece-install now installs the latest Tomcat 9 release

- Tomcat 9 no longer ships with the optional libraries for overriding
  Tomcat's logging from using java.util.logging to using log4j. I've
  therefore simply removed the code for handling this.

- Fixed duplicate dot '.' in the access logs.

- Fixed (non fatal) error on systems where there's no JVM already
  present in /usr/lib/jvm.

- Tested that Tomcat 9 serves /escenic-admin and /escenic and
  /webservice just fine.