### PR TITLE
Added home directories to exclude list

### DIFF
--- a/usr/share/escenic/build-scripts/ece-build
+++ b/usr/share/escenic/build-scripts/ece-build
@@ -1412,6 +1412,10 @@ function _make_conf_package_rpm() {
     "/usr/bin/"
     "/usr/share/"
     "/usr/share/escenic/"
+    "/home/"
+    "/home/ngdb/"
+    "/home/ngio/"
+    "/home/ngx/"
     )
 
     if [[ ! -x /usr/bin/alien || ! -x /usr/bin/fakeroot ]]; then


### PR DESCRIPTION
Added /home/ and the newsgate directories to the exclude list, so the rpm does not take ownership