### PR TITLE
Fix: ece-deploy now can handle publication name or file path with space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.dockerfile.test
 *.ignore
 usr/local/src/unit-tests/shunit2
+*.idea

--- a/usr/local/src/unit-tests/common-io-test.sh
+++ b/usr/local/src/unit-tests/common-io-test.sh
@@ -1,0 +1,41 @@
+#! /usr/bin/env bash
+## author: mah@escenic.com
+
+test_can_determine_make_dir_works_with_space() {
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+  local file_path="${tmp_dir}/test website"
+  local expected=0
+  local actual=
+  make_dir ${file_path} && actual=$? || actual=$?
+  rm -rf ${tmp_dir}
+  assertEquals "Can determine make_dir works with space" "${expected}" "${actual}"
+}
+
+test_can_determine_make_dir_works_without_space() {
+  local tmp_dir=
+  tmp_dir=$(mktemp -d)
+  local file_path="${tmp_dir}/testwebsite"
+  local expected=0
+  local actual=
+  make_dir ${file_path} && actual=$? || actual=$?
+  rm -rf ${tmp_dir}
+  assertEquals "Can determine make_dir works without space" "${expected}" "${actual}"
+}
+
+## @OVERRIDE shunit2
+setUp() {
+  source "$(dirname "$0")/../../../share/escenic/ece-scripts/common-bashing.sh"
+  source "$(dirname "$0")/../../../share/escenic/ece-scripts/common-io.sh"
+}
+
+## @override shunit2
+tearDown() {
+  :
+}
+
+main() {
+  . "$(dirname "$0")"/shunit2/shunit2
+}
+
+main "$@"

--- a/usr/sbin/ece-deploy
+++ b/usr/sbin/ece-deploy
@@ -504,18 +504,18 @@ function remember_state() {
   print_and_log "Remembering all files from the current version of" \
     vosa-conf-$HOSTNAME "..."
   dpkg -L vosa-conf-$HOSTNAME | while read f; do
-    local dir=${1}/vosa-conf-${HOSTNAME}/$(dirname $f)
+    local dir=${1}/vosa-conf-${HOSTNAME}/$(dirname "$f")
     make_dir $dir
-    if [ -d $f ]; then
+    if [ -d "$f" ]; then
       continue
     fi
-    if [ ! -e $f ]; then
-      print_and_log $(yellow WARNING) $f "was installed with the" \
+    if [ ! -e "$f" ]; then
+      print_and_log $(yellow WARNING) "$f" "was installed with the" \
         "vosa-conf-$HOSTNAME package," \
         "however, it's not present on $HOSTNAME."
       continue
     fi
-    cp $f $dir/
+    cp "$f" "$dir/"
   done
 }
 

--- a/usr/share/escenic/ece-scripts/common-io.sh
+++ b/usr/share/escenic/ece-scripts/common-io.sh
@@ -63,11 +63,9 @@ function set_conf_file_value() {
 ##
 ## $@ :: a list of directories
 function make_dir() {
-  for el in $@; do
-    if [ ! -d $el ]; then
-      run mkdir -p $el
-    fi
-  done
+  while read -r el; do
+    mkdir -p "${el}"
+  done <<< "${@}"
 }
 
 ### remove_dir


### PR DESCRIPTION
remember_state use default internal field separator (IFS)
which split word by space
If there any publication name or file path contains space
then it split the file path incorrectly
which cause cause error like 'No such file or directory'

Used custom internal field separator IFS=$'\n'