### PR TITLE
Incorrect rpm package url

### DIFF
--- a/usr/share/escenic/build-scripts/ece-build
+++ b/usr/share/escenic/build-scripts/ece-build
@@ -1391,9 +1391,16 @@ EOF
     for machine in $machine_list; do 
       print_and_log "http://builder.vizrtsaas.com/$customer/releases/vosa-conf-${machine}-${package_version}.deb"
     done
+
+    # formatting revision to match with generated rpm package
+    local rev=$(
+      printf "%s\n" "${release_label}-r${revision}" |
+      sed -r 's#-#_#g' |
+      sed -r 's#(.*)_(.*)#\1-\2#')
+
     print_and_log "--- .rpm configuration packages ---"
     for machine in $machine_list; do
-      print_and_log "http://builder.vizrtsaas.com/$customer/releases/vosa-conf-${machine}-1_${customer//-/_}_${release_label//-/_}-r${revision}.x86_64.rpm"
+      print_and_log "http://builder.vizrtsaas.com/$customer/releases/vosa-conf-${machine}-1_${customer//-/_}_${rev}.x86_64.rpm"
     done
   fi
 }


### PR DESCRIPTION
Format revision to match with generated rpm package

Background: In some causes, `ece-build` prints incorrect URL for rpm package
if the `revision` contains multiple `-` like `2.1.543-274-g30fede64`,
actual generated rpm package replace all `-`  from `revision` except last one.
for example it will convert as  `2.1.543-274-g30fede64` --> `2.1.543_274-g30fede64`
and `2.1.543-274-123-g30fede64` --> `2.1.543_274_123-g30fede64`
