### PR TITLE
The service is called 'mysql' even for MariaDB

### DIFF
--- a/usr/share/escenic/ece-scripts/ece-install.d/database.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/database.sh
@@ -557,11 +557,7 @@ function create_schema() {
     # dropped it above before running the SQL scripts.
   if [ $db_product = "mysql" ]; then
     if ! $(check_mysql_is_running) ; then
-      if [[ "${db_vendor}" == mariadb ]]; then
- 	run service mariadb start
-      else
- 	run service mysql start
-      fi
+      run service mysql start
     fi
     print_and_log "Creating DB $db_schema on $HOSTNAME ..."
     mysql -h $db_host << EOF


### PR DESCRIPTION
- This fixes the DB profile on Debian and derivatives.

- tested on Debian stable 9.5 and Ubuntu 18.04 LTS

- this was a regression bug introduced in
  0080309dd09c3b737ebdac5eac92a6f493b51238