### PR TITLE
New Docker friendly command: ece run

### DIFF
--- a/etc/bash_completion.d/ece
+++ b/etc/bash_completion.d/ece
@@ -21,7 +21,9 @@ _get_sub_commands_for_ece() {
       package
       remove-old-log-files
       repackage
-      restart start
+      restart
+      run
+      start
       status
       stop
       threaddump

--- a/usr/bin/ece
+++ b/usr/bin/ece
@@ -810,6 +810,10 @@ for el in $command; do
         start)
             start_type
             ;;
+        run)
+            export run_in_fg=1
+            start_type
+            ;;
         status)
             print "$(get_status)"
             ;;

--- a/usr/share/escenic/ece-scripts/ece.d/help.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/help.sh
@@ -48,6 +48,7 @@ The following commands are available:
    log            the type's log4j log **)
    outlog         the $id script log (system out log)
    restart        restarts the type
+   run            runs type in the foregrand. Useful for containers.
    start          starts the type
    status         checks if the type is running
    stop           stops the type

--- a/usr/share/escenic/ece-scripts/ece.d/start.sh
+++ b/usr/share/escenic/ece-scripts/ece.d/start.sh
@@ -63,7 +63,11 @@ function start_type() {
 
       export CATALINA_PID=$pid_file
       export CATALINA_OUT=$(get_catalina_out_file)
-      run $tomcat_home/bin/catalina.sh start
+      if [ ${run_in_fg-0} -eq 0 ]; then
+        run $tomcat_home/bin/catalina.sh start
+      else
+        exec ${tomcat_home}/bin/catalina.sh run
+      fi
       ;;
     oc4j)
       export OC4J_JVM_ARGS=$ece_args


### PR DESCRIPTION
- runs the app server in the foreground.

- runs the app server in the foreground.This is especially useful when
  running ECE & search instances in a Docker container were the
  container process is expected to run in the foreground outputting
  its standard log file to standard out.

- Some developers may prefer 'ece run' over 'ece start' too, as it'll
  give them 'Ctrl + c' to stop the app server(s).