### PR TITLE
Make java::_java_get_oracle_tarball_url() follow redirects

### DIFF
--- a/usr/share/escenic/ece-scripts/ece-install.d/java.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/java.sh
@@ -8,7 +8,7 @@ function _java_get_oracle_tarball_url() {
     return
   fi
 
-  curl -s  "${oracle_jdk_download_url}" |
+  wget --quiet --output-document - "${oracle_jdk_download_url}" |
     grep "$(uname -s) x64" |
     grep .tar.gz |
     grep -v demos |


### PR DESCRIPTION
- this makes more robust in case Oracle re-structures its web site
  (again).

- unit test is now passing again:

```
    $ bash ece-install-java-test.sh
    test_can_get_oracle_tarball_url

    Ran 1 test.

    OK
```