### PR TITLE
Fix missing perl module YAML::XS on Ubuntu 18.04

### DIFF
--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -648,7 +648,7 @@ function common_pre_install() {
         #
         # Same goes for json_xs and jq which are required for parsing
         # YAML conf files.
-        install_packages_if_missing "lsb-release libjson-xs-perl libyaml-perl jq"
+        install_packages_if_missing "lsb-release libjson-xs-perl libyaml-perl jq libyaml-libyaml-perl"
     fi
 
     if [ -e /etc/redhat-release ]; then


### PR DESCRIPTION
Including package libyaml-libyaml-perl
into ece-install dependency package list