### PR TITLE
VOSA-500 Fixed getting the RPM URL from Oracle.com

### DIFF
--- a/usr/local/src/unit-tests/ece-install-java-test.sh
+++ b/usr/local/src/unit-tests/ece-install-java-test.sh
@@ -8,6 +8,13 @@ test_can_get_oracle_tarball_url() {
   assertNotNull "Should be able to get Oracle URL"  "${actual}"
 }
 
+test_can_get_oracle_rpm_url() {
+  local actual=
+  actual=$(_java_get_oracle_rpm_url)
+  assertNotNull "Should be able to get Oracle RPM URL"  "${actual}"
+  assertTrue "[[ ${actual} == http*rpm ]]"
+}
+
 ## @override shunit2
 setUp() {
   source "$(dirname "$0")/../../../share/escenic/ece-scripts/ece-install.d/java.sh"

--- a/usr/share/escenic/ece-scripts/ece-install.d/java.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/java.sh
@@ -23,13 +23,13 @@ function _java_get_oracle_rpm_url() {
     return
   fi
 
-  curl -s  "${oracle_jdk_download_url}" |
+  wget --quiet --output-document - "${oracle_jdk_download_url}" |
     grep "$(uname -s) x64" |
     grep .rpm |
     grep -v demos |
     sort -r |
     head -n1 |
-    sed -n -r  's#.*filepath":"(.*)", "MD5".*#\1#p'
+    sed -n -r  's#.*filepath":"(.*)",[ ]*"MD5".*#\1#p'
 }
 
 function install_oracle_java() {


### PR DESCRIPTION
- this is a regression bug because Oracle move their landing pages
  around. Using wget instead of curl solves this as wget follows HTTP
  redirects.

- wrote a unit test that proves that getting the Oracle RPM URL works
  (again).