### PR TITLE
VOSA-496 OpenJDK support hardening

### DIFF
--- a/usr/bin/ece
+++ b/usr/bin/ece
@@ -351,8 +351,10 @@ function set_instance_settings() {
         ece_args=$ece_args" "$gc_rolling_args
       fi
     elif is_java_vendor_openjdk; then
+      # Works on both OpenJDK 8 and 11, if we no longer need OpenJDK
+      # 8, this can be replaced with: -Xlog:gc
       ece_args=${ece_args}"
-        -Xlog:gc:${gc_log}
+        -Xloggc:${gc_log}
       "
     fi
 

--- a/usr/local/src/integration-tests/virtual/clean-slate
+++ b/usr/local/src/integration-tests/virtual/clean-slate
@@ -83,7 +83,7 @@ main() {
       break
     }
     echo '.'
-    sleep 1
+    sleep "${el}"
   done
 
   setup_ece_install_and_conf

--- a/usr/local/src/unit-tests/ece-install-java-test.sh
+++ b/usr/local/src/unit-tests/ece-install-java-test.sh
@@ -16,7 +16,7 @@ test_can_get_oracle_rpm_url() {
 }
 
 test_can_get_java_spec_version() {
-  javac=$(which javac)
+  javac=/usr/lib/jvm/oracle-java8-jdk-amd64/bin/javac
   expected=1.8
   actual=$(echo "${javac}" | _java_get_spec_version)
   assertNotNull "${actual}"
@@ -29,9 +29,15 @@ test_java_spec_1_8_is_ok() {
   assertEquals "Java spec 1.8 is ok" "${expected}" "${actual}"
 }
 
+test_java_spec_9_is_ok() {
+  local expected=0
+  echo 9 | _java_is_spec_supported && actual=$? || actual=$?
+  assertEquals "Java spec 9 is ok" "${expected}" "${actual}"
+}
+
 test_java_spec_10_is_ok() {
   local expected=0
-  echo 11 | _java_is_spec_supported && actual=$? || actual=$?
+  echo 10 | _java_is_spec_supported && actual=$? || actual=$?
   assertEquals "Java spec 10 is ok" "${expected}" "${actual}"
 }
 
@@ -50,6 +56,8 @@ test_has_java_installed() {
 ## @override shunit2
 setUp() {
   source "$(dirname "$0")/../../../share/escenic/ece-scripts/ece-install.d/java.sh"
+  source "$(dirname "$0")/../../../share/escenic/ece-scripts/common-bashing.sh"
+  log=/dev/null
 }
 
 main() {

--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -259,14 +259,8 @@ function install_packages_if_missing() {
     if [ $some_are_missing -eq 0 ]; then
       return
     elif [ $one_time_apt_update_done -eq 0 ]; then
-      # Systemd may be running an update process on boot of new
-      # machines. Therefore, if there's a current apt-get process,
-      # don't do anything.
-      pgrep apt-get &> /dev/null || {
-        log "First running APT update to ensure fresh package list, " \
-            "then continuing the above"
-        run apt-get update
-      }
+      apt_wait_for_lock /var/lib/apt/lists/lock
+      run apt-get update
       one_time_apt_update_done=1
     fi
 
@@ -277,8 +271,10 @@ function install_packages_if_missing() {
     leave_trail trail_package_installed="$*"
 
     if [ $force_packages -eq 1 ]; then
+      apt_wait_for_lock /var/lib/dpkg/lock-frontend
       run apt-get install $apt_opts --assume-yes --force-yes $@
     else
+      apt_wait_for_lock /var/lib/dpkg/lock-frontend
       run apt-get install $apt_opts --assume-yes $@
     fi
   elif [ $on_redhat_or_derivative -eq 1 ]; then
@@ -322,6 +318,7 @@ function install_common_os_packages()
     if [ ${fai_offline_mode-0} -eq 0 ]; then
       curl -s http://apt.escenic.com/archive.key 2>> $log | \
         apt-key add - 1>> $log 2>> $log
+      apt_wait_for_lock /var/lib/apt/lists/lock
       run apt-get update
 
       local package_pool=${fai_apt_vizrt_pool-stable}
@@ -329,9 +326,10 @@ function install_common_os_packages()
       cat >> /etc/apt/auth.conf <<EOF
 
 # added by $(basename "$0") @ $(date)
-machine apt.escenic.com login "${fai_package_apt_user}" password "${fai_package_apt_password}"
+machine apt.escenic.com login ${fai_package_apt_user} password ${fai_package_apt_password}
 EOF
       curl --silent http://apt.escenic.com/repo.key | apt-key add - &>> "${log}"
+      apt_wait_for_lock /var/lib/apt/lists/lock
       run apt-get update
     fi
 

--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -324,10 +324,13 @@ function install_common_os_packages()
         apt-key add - 1>> $log 2>> $log
       run apt-get update
 
-      # Only add our repo if there's no other entry (from our pool or
-      # not), there
       local package_pool=${fai_apt_vizrt_pool-stable}
-      add_apt_source "deb https://${fai_package_apt_user}:${fai_package_apt_password}@apt.escenic.com ${package_pool} main non-free"
+      add_apt_source "deb https://apt.escenic.com ${package_pool} main non-free"
+      cat >> /etc/apt/auth.conf <<EOF
+
+# added by $(basename "$0") @ $(date)
+machine apt.escenic.com login "${fai_package_apt_user}" password "${fai_package_apt_password}"
+EOF
       curl --silent http://apt.escenic.com/repo.key | apt-key add - &>> "${log}"
       run apt-get update
     fi

--- a/usr/share/doc/escenic/ece-install-guide.org
+++ b/usr/share/doc/escenic/ece-install-guide.org
@@ -972,10 +972,55 @@ If you do not want ece-install to touch your */etc/hosts*, you can set
 
 ** Overview of All Configuration Parameters
 The *ece-install* command understands the following settings in
-the *ece-install.yaml*:
+the *ece-install.yaml*.
 
-#+include: "ece-install-conf-reference.org"
+When reading the the table below, it's useful to know that
+=credentials[].site= and =profiles.editor.install= is the notation
+for the YAML snippet:
 
+#+begin_src yaml
+credentials:
+  - site:
+profiles:
+  editor:
+    install:
+#+end_src
+
+|---------------------------------------------+--------------------------------------------------------+------------------------------------------------------|
+| ece-install.yaml setting                    | Example                                                | Comments                                             |
+|---------------------------------------------+--------------------------------------------------------+------------------------------------------------------|
+| credentials[].password                      | bar                                                    | Password, as obtained from Escenic Support           |
+| credentials[].site                          | maven.escenic.com                                      | Website for which the credentials apply              |
+| credentials[].user                          | foo                                                    | User name, as obtained from Escenic Support          |
+| environment.apt.escenic.pool                | eyre                                                   | The APT code name/pool to use.                       |
+| environment.java_home                       | /usr/lib/jvm/java-8-openjdk-amd64                      | If machine already has a JDK, will skip Java install |
+| environment.java_oracle_licence_accepted    | true                                                   | You must accept this to install Oracle JDK           |
+| environment.java_vendor                     | oracle                                                 | The Java vendor. Default is 'openjdk'                |
+| profiles.cue.cors_origins                   | edit.example.com                                       | Allowed CORS origins                                 |
+| profiles.cue.install                        | true                                                   | Web server with CORS & CUE web                       |
+| profiles.db.install                         | true                                                   | Database + ECE schema. Fails if schema exists        |
+| profiles.editor.deploy_white_list           | "webservice indexer-webservice"                        | The webapps to deploy                                |
+| profiles.editor.install                     | yes                                                    | Will install an editorial ECE instance               |
+| profiles.editor.port                        | 8180                                                   | Overrides the port number                            |
+| profiles.publications[].create              | true                                                   | Will create the publication                          |
+| profiles.publications[].domain              | tomorrow-online.example.com                            | How the world will access the publication web site   |
+| profiles.publications[].name                | tomorrow-online                                        | Publication name                                     |
+| profiles.publications[].update_nursery_conf | true                                                   | Update Nursery with publiation URL                   |
+| profiles.search.heap_size                   | 256                                                    | JVM heap size                                        |
+| profiles.search.indexer_ws_uri              | http://localhost:8080/indexer-webservice/index/        | Where to find the =indexer-webservice=               |
+| profiles.search.install                     | yes                                                    | Will install both an indexer and Solr                |
+| profiles.search.port                        | 8180                                                   | Overrides the port number                            |
+| profiles.search.redirect                    | 8133                                                   | Overrides the redirect port number                   |
+| profiles.search.shutdown                    | 8150                                                   | Overrides the shutdown port number                   |
+| profiles.sse_proxy.backends[].password      | foo                                                    | Password for that the ECE user                       |
+| profiles.sse_proxy.backends[].uri           | http://localhost:8080/webservice/escenic/changelog/sse | Content Store's SSE endpoint                         |
+| profiles.sse_proxy.backends[].user          | sse-proxy-user                                         | ECE user to access the sse endpoint                  |
+| profiles.sse_proxy.exposed_host             | proxy.example.com                                      | How the browser will access the proxy                |
+| profiles.sse_proxy.install                  | yes                                                    | SSE proxy micro service                              |
+| packages[].name                             | escenic-content-engine-7.1                             | Name of the RPM or DEB package to install            |
+| packages[].version                          | 7.1.0-5                                                | Package version, only needed for RPM installs        |
+| packages[].arch                             | i386                                                   | Architecture, only needed for RPM installs           |
+|                                             |                                                        |                                                      |
 ** Example Configurations
 Here are a few simple example configurations, you can find more under
 */usr/share/doc/escenic/examples* if you've got the

--- a/usr/share/escenic/ece-scripts/common-os.sh
+++ b/usr/share/escenic/ece-scripts/common-os.sh
@@ -284,3 +284,23 @@ get_secondary_interfaces() {
     awk '{print $1}' |
     sed 1d
 }
+
+## Method which will wait for a certain amount of time to ensure
+## there's no other APT process running. Systemd may be running an
+## update process on boot of new machines or there may be a daemon
+## like unattended-upgrades running which also grabs the APT lock
+## file.
+##
+## Requires that lsof is installed.
+##
+## $1 :: optional path to the lock file to check, default is
+##       /var/lib/dpkg/lock if none is specified.
+apt_wait_for_lock() {
+  local file=${1-/var/lib/dpkg/lock}
+  if [[ -x /usr/bin/lsof && -e "${file}" ]]; then
+    for i in {0..20}; do
+      lsof "${file}" || break
+      sleep "${i}"
+    done
+  fi
+}

--- a/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
@@ -86,7 +86,7 @@ function set_up_app_server() {
   if [ -n "$user_presentation_indexer_ws_uri" ]; then
     presentation_indexer_ws_uri=$user_presentation_indexer_ws_uri
   else
-    presentation_indexer_ws_uri=http://${HOSTNAME}:${appserver_port}/indexer-webservice/presentation-index/
+    presentation_indexer_ws_uri=http://${HOSTNAME}:${fai_editor_port-appserver_port}/indexer-webservice/presentation-index/
   fi
 
   leave_trail "trail_presentation_indexer_ws_uri=${presentation_indexer_ws_uri}"

--- a/usr/share/escenic/ece-scripts/ece-install.d/database.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/database.sh
@@ -138,6 +138,7 @@ function set_up_repository_if_possible() {
 
       if ! apt-cache > /dev/null show $mysql_server_packages; then
         print_and_log "Setting Up the $db_vendor Repository ..."
+        apt_wait_for_lock /var/lib/apt/lists/lock
         run apt-get update
       fi
     else


### PR DESCRIPTION
- Put APT credentials in /etc/apt/auth.conf instead of sources.list
- environment.java_home now skips Java installation for both OpenJDK
  and Oracle JDK (before it only skipped it for Oracle JDK).
- '/usr/bin/ece start' now works on OpenJDK 9 too
- clean-slate integration test does incremental sleeps while waiting
  for the vbox machine to come up
- ece-install support for OpenJDK 9
- fixed OpenJDK 10 unit test
- documented the most common ece-install.yaml settings in
  ece-install-guide.org
- fallback JDK package on Debian based machines is now
  default-jdk-headless
- fixed java::_java_get_spec_version, can't run java process in run
  wrapper as it will not return any value.