### PR TITLE
Added escenic-jstat systemd service

### DIFF
--- a/lib/systemd/system/escenic-jstat@.service
+++ b/lib/systemd/system/escenic-jstat@.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Jstat process for %i
+
+[Service]
+
+# 1. Check if the pidfile is a valid pid file, if not, do nothing.
+# 2. redirect output to a log-file (exec 2>&1), truncate it.
+# 3. Become the user that owns the pidfile (gosu)
+# 4. chain (exec) to the jstat process so that systemd can kill jstat
+# jstat will quit when the process in pidfile quits
+ExecStart=/bin/bash -c 'if pgrep &> /dev/null --pidfile /var/run/escenic/%i.pid; then echo found pid; exec 2>&1 > /var/log/escenic/%i-jstat.log; date --utc --iso=seconds; exec gosu $(stat -c %%U /var/run/escenic/%i.pid) jstat -gcutil $(cat /var/run/escenic/%i.pid) 1000; fi'
+
+# This service quits when the process being monitored dies, and then
+# it is respawned continuously until the pidfile lists a pid that can
+# be monitored again.
+Restart=always
+RestartSec=12
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
To enable, for any java process that writes its pid to a pidfile in
/var/run/escenic, for example 'engine1.pid':

  systemctl enable escenic-jstat@engine1
  systemctl start escenic-jstat@engine1

Then after a few seconds, you will see in
/var/log/escenic/engine1-jstat.log:

```
2019-01-25T12:58:25+00:00
  S0     S1     E      O      M     CCS    YGC     YGCT    FGC    FGCT     GCT
 10.55   0.00  41.13  27.62  97.09  94.06   4382  169.803     6    0.218  170.021
 10.55   0.00  41.14  27.62  97.09  94.06   4382  169.803     6    0.218  170.021
 10.55   0.00  41.14  27.62  97.09  94.06   4382  169.803     6    0.218  170.021
```

Whenever engine1 is restarted, this logfile will be truncated, with no rotation.
