### PR TITLE
VOSA-552 Bugfix in ece-install:get_content_engine_dir()

### DIFF
--- a/usr/sbin/ece-install
+++ b/usr/sbin/ece-install
@@ -160,6 +160,7 @@ function init() {
 function get_content_engine_dir() {
   if [ "${fai_package_enabled-0}" -eq 1 ]; then
     find "${escenic_root_dir}"/escenic-content-engine-* -maxdepth 0 |
+      grep -v escenic-content-engine-scripts |
       tail -n 1
   else
     printf "%s\n" "${escenic_root_dir}/engine"


### PR DESCRIPTION
- when scripts are installed as a package, using the latest release
  process build, the path of the escenic-content-engine-scripts
  interfere with the logic of get_content_engine_dir(). This has now
  been fixed.

- this is, at least indirectly, a regression introduced in
  a595d3dcb763010e59edfea043acf5495368249b