### PR TITLE
Removed websocket JARs, improved Tomcat startup time with 15-16 seconds

### DIFF
--- a/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
+++ b/usr/share/escenic/ece-scripts/ece-install.d/app-server.sh
@@ -482,6 +482,16 @@ EOF
   tomcat_disable_manifest_scanning_of_jars ${tomcat_base}/conf/context.xml
   pretty_print_xml $tomcat_base/conf/context.xml
   set_up_logging
+  tomcat_speedup_remove_websockets
+}
+
+function tomcat_speedup_remove_websockets() {
+  for el in websocket-api.jar tomcat-websocket.jar; do
+    if [ -e "${tomcat_home}/lib/${el}" ]; then
+      log "Optimising Tomcat, removing ${el} ..."
+      run rm "${tomcat_home}/lib/${el}"
+    fi
+  done
 }
 
 ## This applies to Tomcat 8.0.41 and up. Turn off scanning of


### PR DESCRIPTION
- removed websocket support as none of the ECE webapps or indexer uses
  these APIs.