### PR TITLE
Fix RPM package deploy does not overwrite existing config

### DIFF
--- a/usr/share/escenic/build-scripts/ece-build
+++ b/usr/share/escenic/build-scripts/ece-build
@@ -1449,7 +1449,6 @@ function _make_conf_package_rpm() {
     for el in "${remove_dir_list[@]}"; do
         sed -r -i "s#(%dir \"${el}\"\$)##" -- *.spec
     done
-    sed -i 's#^%config #%config(noreplace) #' -- *.spec
 
     file=$(
     LC_ALL=C fakeroot \


### PR DESCRIPTION
The configuration from RPM package should now overwrite the configuration that was done manually on disk. The file on disk should be renamed to .rmpsave.
Earlier, The latest configuration file from RPM package keeps into .rpmnew file without touch existing conf file.